### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # City Data
 
 ## Requirements
-- NPM
-- Bower
+- npm
 - Webpack
 - Java JRE (needed to run protractor)
 
 ## Installations
 - npm install
-- npm start
+- NODE_ENV=development npm start
 - Open the server at http://localhost:8080/
 
 ## Other useful commands

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -130,7 +130,7 @@
                                         <div class="c-dashboard__social-link">
                                             <a
                                               class="o-btn o-btn--link--inverse"
-                                              href="https://github.com/DatapuntAmsterdam"
+                                              href="https://github.com/Amsterdam"
                                               rel="external"
                                               target="_blank" rel="noopener">GitHub</a>
                                         </div>


### PR DESCRIPTION
- Remove unused requirement
- Add NODE_ENV variable

---

Hi,
It seems that Bower has been removed from the repository recently, but README has it as a requirement. Within this PR, it'll be removed as well.
Also, if you just use `npm start` as written in README file, you'll most likely end up with an error because of `babel-preset-react-app` package. It requires you to enter one of `development`, `test` or `production` values. Instead of adding it to the `start` script and forcing people to use `development` all the time, I think this is a better alternative.

I hope you'll accept this PR, thanks in advance. 

Best,
G.