### PR TITLE
React bump & React devtools warning log disabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16659,9 +16659,9 @@
       "integrity": "sha512-E01uqSgP4JJIZNCaug2rV8g3JcIabLP09POLJ6wpM0oWftfnjqIWHYipUuscltCjQAxsPV3FFnMkW22/93qgig=="
     },
     "react": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.0.0.tgz",
-      "integrity": "sha1-zn348ZQbA28Cssyp29DLHw6FXi0=",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -16727,9 +16727,9 @@
       }
     },
     "react-dom": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.0.0.tgz",
-      "integrity": "sha1-nMMHnD3NcNTG4BuEqrKn40wwP1g=",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -139,8 +139,8 @@
     "puppeteer": "^0.13.0",
     "raf": "^3.4.0",
     "raven-js": "^3.19.1",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "16.2.0",
+    "react-dom": "16.2.0",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
     "redux-saga": "^0.15.6"

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -102,6 +102,9 @@ function commonConfig({ nodeEnv }) {
       ]
     },
     plugins: [
+      new webpack.DefinePlugin({
+        '__REACT_DEVTOOLS_GLOBAL_HOOK__': '({ isDisabled: true })'
+      }),
       new CleanWebpackPlugin([dist]),
       new webpack.optimize.CommonsChunkPlugin({
         name: 'vendor',


### PR DESCRIPTION
Gets rid of: "Download the React DevTools for a better development experience: https://fb.me/react-devtools".

TODO: Check extension still works if installed (mine isn't working so can't test).