### PR TITLE
DP-5480

### DIFF
--- a/src/detail/components/graphs/grondexploitatie-grafiek-gefaseerde-begroting/_grondexploitatie-grafiek-gefaseerde-begroting.scss
+++ b/src/detail/components/graphs/grondexploitatie-grafiek-gefaseerde-begroting/_grondexploitatie-grafiek-gefaseerde-begroting.scss
@@ -4,6 +4,7 @@
 
 .grondexploitatie-grafiek-gefaseerde-begroting {
   margin-top: 50px;
+  overflow: hidden;
   width: 100%;
 
   &__title {

--- a/src/detail/components/graphs/grondexploitatie-grafiek-totale-begroting/_grondexploitatie-grafiek-totale-begroting.scss
+++ b/src/detail/components/graphs/grondexploitatie-grafiek-totale-begroting/_grondexploitatie-grafiek-totale-begroting.scss
@@ -4,6 +4,7 @@
 
 .grondexploitatie-grafiek-totale-begroting {
   margin-top: 50px;
+  overflow: hidden;
   width: 100%;
 
   &__title {


### PR DESCRIPTION
The responsive containers set some `visibility:hidden` elements. This breaks in IE11. As the width of the graphs itself is always correct, because of the responsive wrapper, we can safely set an overflow: hidden on the parent element.