### PR TITLE
double check if the title actually changed

### DIFF
--- a/modules/atlas/components/document-title/document-title.directive.js
+++ b/modules/atlas/components/document-title/document-title.directive.js
@@ -99,6 +99,7 @@ import * as piwik from '../../../../src/shared/services/piwik-tracker/piwik-trac
         function linkFn (scope, element, attrs, controller, transcludeFn) {
             const baseTitle = transcludeFn().text();
             let trackerInterval;
+            let previousTitle;
 
             store.subscribe(setTitle);
 
@@ -106,9 +107,10 @@ import * as piwik from '../../../../src/shared/services/piwik-tracker/piwik-trac
                 // make sure that the page is finished loading.
                 // before actually tracking the navigation
                 const state = store.getState();
-                if (!isStateLoading(state)) {
+                if (!isStateLoading(state) && scope.title !== previousTitle) {
                     $interval.cancel(trackerInterval);
                     piwik.trackPageNavigation();
+                    previousTitle = scope.title;
                 }
             }
 


### PR DESCRIPTION
Bij het loggen van de piwik calls bij document title change is deze bug geintroduceerd. Nu met een extra check of de titel wel echt is veranderd voorkomen we dat de piwik call bij elke state-change wordt getriggerd