### PR TITLE
Dedicated button component instead of isButton dp-link hack

### DIFF
--- a/modules/shared/components/button/button.component.js
+++ b/modules/shared/components/button/button.component.js
@@ -20,7 +20,6 @@
 
     function DpButtonController ($scope, store, ACTIONS) {
         const vm = this;
-        console.log(vm.type);
 
         vm.className = vm.className || 'o-btn o-btn--link';
 

--- a/modules/shared/components/button/button.component.js
+++ b/modules/shared/components/button/button.component.js
@@ -1,0 +1,41 @@
+(function () {
+    'use strict';
+
+    angular
+        .module('dpShared')
+        .component('dpButton', {
+            templateUrl: 'modules/shared/components/button/button.html',
+            transclude: true,
+            bindings: {
+                className: '@',
+                hoverText: '@',
+                type: '@',
+                payload: '<'
+            },
+            controller: DpButtonController,
+            controllerAs: 'vm'
+        });
+
+    DpButtonController.$inject = ['$scope', 'store', 'ACTIONS'];
+
+    function DpButtonController ($scope, store, ACTIONS) {
+        const vm = this;
+        console.log(vm.type);
+
+        vm.className = vm.className || 'o-btn o-btn--link';
+
+        vm.dispatch = function () {
+            store.dispatch(getAction(vm.type, vm.payload));
+        };
+
+        function getAction (type, payload) {
+            const action = {
+                type: ACTIONS[type] || type
+            };
+            if (angular.isDefined(payload)) {
+                action.payload = payload;
+            }
+            return action;
+        }
+    }
+})();

--- a/modules/shared/components/button/button.component.mock.js
+++ b/modules/shared/components/button/button.component.mock.js
@@ -9,7 +9,7 @@
 
     dpButtonDirective.$inject = ['store', 'ACTIONS'];
 
-    function dpButtonDirective(store, ACTIONS) {
+    function dpButtonDirective (store, ACTIONS) {
         return {
             template: '<button ng-click="click()" class="{{className}}" title="{{hoverText}}">' +
                 '<ng-transclude></ng-transclude><span class="u-sr-only">{{hoverText}}</span></button>',

--- a/modules/shared/components/button/button.component.mock.js
+++ b/modules/shared/components/button/button.component.mock.js
@@ -1,0 +1,45 @@
+// This component is just an mock of the dp-link component
+// Is only used in the tests to simplify the test process
+(function () {
+    'use strict';
+
+    angular
+        .module('dpShared')
+        .directive('dpButton', dpButtonDirective);
+
+    dpButtonDirective.$inject = ['store', 'ACTIONS'];
+
+    function dpButtonDirective(store, ACTIONS) {
+        return {
+            template: '<button ng-click="click()" class="{{className}}" title="{{hoverText}}">' +
+                '<ng-transclude></ng-transclude><span class="u-sr-only">{{hoverText}}</span></button>',
+            transclude: true,
+            link: linkFn,
+            scope: {
+                className: '@',
+                hoverText: '@',
+                type: '@',
+                payload: '='
+            }
+        };
+
+        function linkFn (scope, element) {
+            /* istanbul ignore next */
+            scope.className = scope.className || 'o-btn o-btn--link qa-button-mock';
+            scope.click = clickHandler;
+
+            function clickHandler () {
+                /* istanbul ignore next */
+                var action = angular.isDefined(scope.payload) ? {
+                    type: ACTIONS[scope.type],
+                    payload: scope.payload
+                } : {
+                    type: ACTIONS[scope.type]
+                };
+
+                store.dispatch(action);
+            }
+        }
+    }
+})();
+

--- a/modules/shared/components/button/button.html
+++ b/modules/shared/components/button/button.html
@@ -1,1 +1,1 @@
-<button ng-click="vm.dispatch()" class="{{vm.className}} qa-dp-link" title="{{vm.hoverText}}"><ng-transclude></ng-transclude></button>
+<button ng-click="vm.dispatch()" class="{{vm.className}} qa-dp-button" title="{{vm.hoverText}}"><ng-transclude></ng-transclude></button>

--- a/modules/shared/components/button/button.html
+++ b/modules/shared/components/button/button.html
@@ -1,0 +1,1 @@
+<button ng-click="vm.dispatch()" class="{{vm.className}} qa-dp-link" title="{{vm.hoverText}}"><ng-transclude></ng-transclude></button>

--- a/modules/shared/components/link/link.component.js
+++ b/modules/shared/components/link/link.component.js
@@ -23,14 +23,13 @@
         const vm = this;
         vm.activeUrl = $location.url();
 
-        const BUTTON = 'button',
-            LINK = 'a';
-
         vm.className = vm.className || 'o-btn o-btn--link';
         vm.inline = vm.inline || false;
 
         $scope.$watch('vm.payload', function () {
-            vm.tagName = getTagName(vm.type, vm.payload);
+            vm.href = getHref(vm.type, vm.payload);
+            // Do not catch a click event and handle the state change
+            // internally, this prevents users from CTRL/CMD clicking!
         });
 
         vm.dispatch = function () {
@@ -53,17 +52,6 @@
                 action.payload = payload;
             }
             return action;
-        }
-
-        function getTagName (type, payload) {
-            if (ACTIONS[type] && ACTIONS[type].isButton) {
-                return BUTTON;
-            } else {
-                vm.href = getHref(type, payload);
-                // Do not catch a click event and handle the state change
-                // internally, this prevents users from CTRL/CMD clicking!
-                return LINK;
-            }
         }
 
         function getHref (type, payload) {

--- a/modules/shared/components/link/link.html
+++ b/modules/shared/components/link/link.html
@@ -1,6 +1,5 @@
 <span class="c-link__wrapper" ng-class="{
     'c-link__wrapper--inine-block': {{vm.inline}}
 }">
-    <button ng-if="vm.tagName === 'button'" ng-click="vm.dispatch()" class="{{vm.className}} qa-dp-link" title="{{vm.hoverText}}"><ng-transclude></ng-transclude></button>
-    <a ng-if="vm.tagName === 'a'" ng-href="{{vm.href}}" class="{{vm.className}} qa-dp-link" title="{{vm.hoverText}}"><ng-transclude></ng-transclude></a>
+    <a ng-href="{{vm.href}}" class="{{vm.className}} qa-dp-link" title="{{vm.hoverText}}"><ng-transclude></ng-transclude></a>
 </span>

--- a/modules/straatbeeld/components/straatbeeld/straatbeeld.html
+++ b/modules/straatbeeld/components/straatbeeld/straatbeeld.html
@@ -2,12 +2,12 @@
     <dp-toggle-straatbeeld-fullscreen is-fullscreen="state.isFullscreen"></dp-toggle-straatbeeld-fullscreen>
 
     <div class="qa-close">
-        <dp-link type="HIDE_STRAATBEELD" class-name="c-straatbeeld__close c-toggle-button" hover-text="Sluiten">
+        <dp-button type="HIDE_STRAATBEELD" class-name="c-straatbeeld__close c-toggle-button" hover-text="Sluiten">
             <?xml version="1.0" encoding="UTF-8"?>
             <svg viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <polygon points="512 577.139159 718.860841 784 784 718.860841 577.139159 512 784 305.139159 718.860841 240 511.542265 447.318576 305.139159 240 240 305.139159 446.879667 511.981174 240 718.860841 305.139159 784"></polygon>
             </svg>
-        </dp-link>
+        </dp-button>
     </div>
 
     <div class="c-straatbeeld__marzipano js-marzipano-viewer" ng-mousemove="updateOrientation()"></div>

--- a/src/index.js
+++ b/src/index.js
@@ -173,6 +173,7 @@ import '../modules/shared/components/anchor-link/anchor-link.component';
 import '../modules/shared/components/anchor-link/anchor-link.constant';
 import '../modules/shared/components/anchor-link/anchor-link.run';
 import '../modules/shared/components/api-error/api-error.component';
+import '../modules/shared/components/button/button.component';
 import '../modules/shared/components/coordinates/coordinates.filter';
 import '../modules/shared/components/dcatd-button/dcatd-button.component';
 import '../modules/shared/components/expand-collapse/expand-collapse.directive';

--- a/src/map/containers/draw-tool/DrawToolContainer.test.jsx
+++ b/src/map/containers/draw-tool/DrawToolContainer.test.jsx
@@ -91,7 +91,6 @@ describe('DrawToolContainer', () => {
 
   beforeEach(() => {
     store = configureMockStore()({ ...initialState });
-    // mapEndDrawing.mockImplementation(() => ({ type: MAP_END_DRAWING }));
   });
 
   afterEach(() => {

--- a/src/shared/actions.js
+++ b/src/shared/actions.js
@@ -11,8 +11,6 @@ import {
 //   The action will not change the url
 // - replace: true
 //   The action will replace the url (not adding a new entry in the browser history)
-// - isButton: true
-//   The action will be triggered by a button instead of a link
 //
 //
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -75,16 +73,10 @@ export default {
   },
   MAP_START_DRAWING: {
     id: 'MAP_START_DRAWING',
-    ignore: true,
-    isButton: true
-  },
-  MAP_CLEAR_DRAWING: {
-    id: 'MAP_CLEAR_DRAWING',
-    isButton: true
+    ignore: true
   },
   MAP_END_DRAWING: {
-    id: 'MAP_END_DRAWING',
-    isButton: true
+    id: 'MAP_END_DRAWING'
   },
 
   FETCH_DETAIL: {

--- a/src/shared/actions.js
+++ b/src/shared/actions.js
@@ -119,8 +119,7 @@ export default {
     replace: true
   },
   STRAATBEELD_FULLSCREEN: {
-    id: 'STRAATBEELD_FULLSCREEN',
-    isButton: true
+    id: 'STRAATBEELD_FULLSCREEN'
   },
   HIDE_STRAATBEELD: {
     id: 'HIDE_STRAATBEELD',

--- a/src/shared/actions.js
+++ b/src/shared/actions.js
@@ -150,8 +150,7 @@ export default {
     id: 'NAVIGATE_DATA_SELECTION'
   },
   SET_DATA_SELECTION_VIEW: {
-    id: 'SET_DATA_SELECTION_VIEW',
-    isButton: true
+    id: 'SET_DATA_SELECTION_VIEW'
   },
 
   SHOW_HOME: {

--- a/src/shared/actions.js
+++ b/src/shared/actions.js
@@ -78,7 +78,7 @@ export default {
   MAP_END_DRAWING: {
     id: 'MAP_END_DRAWING'
   },
-  
+
   FETCH_DETAIL: {
     id: 'FETCH_DETAIL',
     ignore: true

--- a/src/shared/actions.js
+++ b/src/shared/actions.js
@@ -124,8 +124,7 @@ export default {
   },
   HIDE_STRAATBEELD: {
     id: 'HIDE_STRAATBEELD',
-    ignore: true,
-    isButton: true
+    ignore: true
   },
   SET_STRAATBEELD_ORIENTATION: {
     id: 'SET_STRAATBEELD_ORIENTATION',

--- a/src/shared/actions.js
+++ b/src/shared/actions.js
@@ -78,11 +78,10 @@ export default {
   MAP_END_DRAWING: {
     id: 'MAP_END_DRAWING'
   },
-
+  
   FETCH_DETAIL: {
     id: 'FETCH_DETAIL',
-    ignore: true,
-    isButton: false
+    ignore: true
   },
   SHOW_DETAIL: {
     id: 'SHOW_DETAIL'

--- a/src/test-index.js
+++ b/src/test-index.js
@@ -224,6 +224,7 @@ import '../modules/straatbeeld/straatbeeld.vendor';
 
 // The mocks
 import 'angular-mocks';
+import '../modules/shared/components/button/button.component.mock';
 import '../modules/shared/components/link/link.component.mock';
 
 // All our modules' javascript tests


### PR DESCRIPTION
changed:
* Switch between map and table address view using link instead of button.
* Draw tool clear, start and stop `isButton` removed. These old actions aren't really even being used anymore.