### PR TITLE
Feature/cypress run one go

### DIFF
--- a/Dockerfile-e2e
+++ b/Dockerfile-e2e
@@ -14,8 +14,7 @@ COPY package.json package-lock.json /home/
 RUN git config --global url."https://".insteadOf git:// && \
     git config --global url."https://github.com/".insteadOf git@github.com: && \
     CI=true npm install \
-      cypress@`node -p -e "require('./package-lock.json').dependencies.cypress.version"` \
-      bluebird@`node -p -e "require('./package-lock.json').dependencies.bluebird.version"`
+      cypress@`node -p -e "require('./package-lock.json').dependencies.cypress.version"`
 
 COPY src /home/src
 COPY test /home/test

--- a/Dockerfile-e2e
+++ b/Dockerfile-e2e
@@ -14,7 +14,8 @@ COPY package.json package-lock.json /home/
 RUN git config --global url."https://".insteadOf git:// && \
     git config --global url."https://github.com/".insteadOf git@github.com: && \
     CI=true npm install \
-      cypress@`node -p -e "require('./package-lock.json').dependencies.cypress.version"`
+      cypress@`node -p -e "require('./package-lock.json').dependencies.cypress.version"` \
+      bluebird@`node -p -e "require('./package-lock.json').dependencies.bluebird.version"`
 
 COPY src /home/src
 COPY test /home/test

--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,6 @@
 {
   "baseUrl": "http://localhost:8080",
   "fixturesFolder": "test/cypress/fixtures",
-  "integrationFolder": "test/cypress/integration",
   "pluginsFile": "test/cypress/plugins/index.js",
   "requestTimeout": 15000,
   "screenshotsFolder": "test/cypress/screenshots",

--- a/scripts/cypress/cypress-run.js
+++ b/scripts/cypress/cypress-run.js
@@ -4,7 +4,8 @@ const SCRIPTS_FOLDER =  process.env.SCRIPTS_FOLDER || 'test/cypress/integration'
 
 cypress.run({
   config: {
-    integrationFolder: SCRIPTS_FOLDER
+    integrationFolder: SCRIPTS_FOLDER,
+    numTestsKeptInMemory: 10
   },
   env: {
     API_ROOT: process.env.API_ROOT,

--- a/scripts/cypress/cypress-run.js
+++ b/scripts/cypress/cypress-run.js
@@ -2,7 +2,7 @@ const cypress = require('cypress')
 
 const SCRIPTS_FOLDER =  process.env.SCRIPTS_FOLDER || 'test/cypress/integration';
 
-cypress.run({
+return cypress.run({
   config: {
     integrationFolder: SCRIPTS_FOLDER,
     numTestsKeptInMemory: 10
@@ -15,4 +15,10 @@ cypress.run({
     PASSWORD_EMPLOYEE_PLUS: process.env.PASSWORD_EMPLOYEE_PLUS
   }
 })
-
+.then((results) => {
+  console.log(results)
+})
+.catch((err) => {
+  console.error(err)
+  process.exit(numFailed)
+})

--- a/scripts/cypress/cypress-run.js
+++ b/scripts/cypress/cypress-run.js
@@ -1,55 +1,17 @@
-// Based on: https://github.com/cypress-io/cypress/issues/416#issuecomment-337400871
-// Runs Cypress runner per integration test. Mitigates memory hogging issues.
-// Once a Cypress version is released that clears renderer
-// between tests this hack (entire file) can be removed.
-
 const cypress = require('cypress')
-const Promise = require('bluebird')
-
-const glob = Promise.promisify(require('glob'))
-
-const started = new Date()
-let numFailed = 0
 
 const SCRIPTS_FOLDER =  process.env.SCRIPTS_FOLDER || 'test/cypress/integration';
 
-return glob(SCRIPTS_FOLDER + '/**/*', {
-  nodir: true,
-  realpath: true,
+cypress.run({
+  config: {
+    integrationFolder: SCRIPTS_FOLDER
+  },
+  env: {
+    API_ROOT: process.env.API_ROOT,
+    USERNAME_EMPLOYEE: process.env.USERNAME_EMPLOYEE,
+    USERNAME_EMPLOYEE_PLUS: process.env.USERNAME_EMPLOYEE_PLUS,
+    PASSWORD_EMPLOYEE: process.env.PASSWORD_EMPLOYEE,
+    PASSWORD_EMPLOYEE_PLUS: process.env.PASSWORD_EMPLOYEE_PLUS
+  }
 })
-.tap((specs) => {
-  console.log('Found ', specs.length, ' specs:\n\n', specs)
-})
-.each((spec) => {
-  console.log('\nRunning spec:', spec)
 
-  return cypress.run({
-    spec: spec,
-    config: {
-      integrationFolder: SCRIPTS_FOLDER
-    },
-    env: {
-      API_ROOT: process.env.API_ROOT,
-      USERNAME_EMPLOYEE: process.env.USERNAME_EMPLOYEE,
-      USERNAME_EMPLOYEE_PLUS: process.env.USERNAME_EMPLOYEE_PLUS,
-      PASSWORD_EMPLOYEE: process.env.PASSWORD_EMPLOYEE,
-      PASSWORD_EMPLOYEE_PLUS: process.env.PASSWORD_EMPLOYEE_PLUS
-    }
-  })
-  .then((results) => {
-    numFailed += results.failures
-  })
-})
-.then(() => {
-  const duration = new Date() - started
-
-  console.log('\n--All Done--\n')
-  console.log('Total duration:', duration) // format this however you like
-  console.log('Exiting with final code:', numFailed)
-
-  process.exit(numFailed)
-})
-.catch((err) => {
-  console.error(err)
-  throw err
-})


### PR DESCRIPTION
Let cypress run all specs. Custom sequantially running cypress code removed. Workaround should no longer be needed according to comments.

Speedup from 592 seconds to 370 seconds, 40% faster.