### PR TITLE
Bugfix/cypruss visible check

### DIFF
--- a/test/cypress/integration/permissions-employee_spec.js
+++ b/test/cypress/integration/permissions-employee_spec.js
@@ -143,7 +143,9 @@ describe('employee permissions', () => {
     });
     cy.get(queries.legendToggleItem).contains(values.vestigingenHoreca).click();
     cy.get(queries.legendNotification).should('not.exist');
+    /** Leave out visible for elements that could be hidden by overscroll
     cy.get(queries.legendItem).contains(values.legendCafeValue).should('exist').and('be.visible');
+    */
   });
 
   it('7A. Should allow an employee to view "Vestigingen"', () => {

--- a/test/cypress/integration/permissions-employee_spec.js
+++ b/test/cypress/integration/permissions-employee_spec.js
@@ -146,6 +146,7 @@ describe('employee permissions', () => {
     /** Leave out visible for elements that could be hidden by overscroll
     cy.get(queries.legendItem).contains(values.legendCafeValue).should('exist').and('be.visible');
     */
+    cy.get(queries.legendItem).contains(values.legendCafeValue).should('exist');
   });
 
   it('7A. Should allow an employee to view "Vestigingen"', () => {


### PR DESCRIPTION
Leave out be.visible for element that could be partially hidden by overscroll parent