### PR TITLE
DP-6466: Always use bi as missiontype, even when showing the most rec…

### DIFF
--- a/src/map/services/map-layers/map-layers.config.js
+++ b/src/map/services/map-layers/map-layers.config.js
@@ -568,7 +568,10 @@ export default [
   {
     id: 'pano',
     url: 'maps/panorama',
-    layers: ['panorama_new']
+    layers: ['panorama_new'],
+    params: {
+      mission_type: 'bi'
+    }
   },
   {
     id: 'pano2016bi',

--- a/src/panorama/components/StatusBar/__snapshots__/StatusBar.test.jsx.snap
+++ b/src/panorama/components/StatusBar/__snapshots__/StatusBar.test.jsx.snap
@@ -12,14 +12,26 @@ exports[`StatusBar should render 1`] = `
         Object {
           "label": "Meest recent",
           "layerName": "pano",
-          "missionType": "",
+          "missionType": "bi",
           "year": 0,
         },
         Object {
-          "label": "Alleen 2018 regulier",
+          "label": "Alleen 2018",
           "layerName": "pano2018bi",
           "missionType": "bi",
           "year": 2018,
+        },
+        Object {
+          "label": "Alleen 2017",
+          "layerName": "pano2017bi",
+          "missionType": "bi",
+          "year": 2017,
+        },
+        Object {
+          "label": "Alleen 2016",
+          "layerName": "pano2016bi",
+          "missionType": "bi",
+          "year": 2016,
         },
         Object {
           "label": "Alleen 2018 WOZ",
@@ -28,22 +40,10 @@ exports[`StatusBar should render 1`] = `
           "year": 2018,
         },
         Object {
-          "label": "Alleen 2017 regulier",
-          "layerName": "pano2017bi",
-          "missionType": "bi",
-          "year": 2017,
-        },
-        Object {
           "label": "Alleen 2017 WOZ",
           "layerName": "pano2017woz",
           "missionType": "woz",
           "year": 2017,
-        },
-        Object {
-          "label": "Alleen 2016 regulier",
-          "layerName": "pano2016bi",
-          "missionType": "bi",
-          "year": 2016,
         },
       ]
     }

--- a/src/panorama/ducks/constants.js
+++ b/src/panorama/ducks/constants.js
@@ -11,12 +11,12 @@ export const SET_PANORAMA_VIEW = `${REDUCER_KEY}/SET_PANORAMA_VIEW`;
 export const CLOSE_PANORAMA = `${REDUCER_KEY}/CLOSE_PANORAMA`;
 export const FETCH_PANORAMA_REQUEST_TOGGLE = `${REDUCER_KEY}/FETCH_PANORAMA_REQUEST_TOGGLE`;
 export const historyOptions = [
-  { year: 0, missionType: '', label: 'Meest recent', layerName: 'pano' },
-  { year: 2018, missionType: 'bi', label: 'Alleen 2018 regulier', layerName: 'pano2018bi' },
+  { year: 0, missionType: 'bi', label: 'Meest recent', layerName: 'pano' },
+  { year: 2018, missionType: 'bi', label: 'Alleen 2018', layerName: 'pano2018bi' },
+  { year: 2017, missionType: 'bi', label: 'Alleen 2017', layerName: 'pano2017bi' },
+  { year: 2016, missionType: 'bi', label: 'Alleen 2016', layerName: 'pano2016bi' },
   { year: 2018, missionType: 'woz', label: 'Alleen 2018 WOZ', layerName: 'pano2018woz' },
-  { year: 2017, missionType: 'bi', label: 'Alleen 2017 regulier', layerName: 'pano2017bi' },
-  { year: 2017, missionType: 'woz', label: 'Alleen 2017 WOZ', layerName: 'pano2017woz' },
-  { year: 2016, missionType: 'bi', label: 'Alleen 2016 regulier', layerName: 'pano2016bi' }
+  { year: 2017, missionType: 'woz', label: 'Alleen 2017 WOZ', layerName: 'pano2017woz' }
 ];
 
 export const initialState = {

--- a/src/panorama/ducks/panorama.test.js
+++ b/src/panorama/ducks/panorama.test.js
@@ -27,7 +27,7 @@ describe('Panorama Reducer', () => {
       history: {
         label: 'Meest recent',
         layerName: 'pano',
-        missionType: '',
+        missionType: 'bi',
         year: 0
       },
       hotspots: [],

--- a/src/panorama/services/panorama-api/panorama-api.js
+++ b/src/panorama/services/panorama-api/panorama-api.js
@@ -37,9 +37,9 @@ const prefix = PANORAMA_CONFIG.PANORAMA_ENDPOINT_PREFIX;
 const suffix = PANORAMA_CONFIG.PANORAMA_ENDPOINT_SUFFIX;
 
 export const getLocationHistoryParams = (location, history) => {
-  const yearTypeMission = (history && history.year)
-    ? `&mission_year=${history.year}&mission_type=${history.missionType}`
-    : '';
+  const missionYear = (history && history.year) ? `&mission_year=${history.year}` : '';
+  const missionType = (history && history.missionType) ? `&mission_type=${history.missionType}` : '';
+  const yearTypeMission = `${missionYear}${missionType}`;
   const newestInRange = 'newest_in_range=true';
   const pageSize = 'page_size=1';
 

--- a/test/e2e/cypress/integration/panorama_spec.js
+++ b/test/e2e/cypress/integration/panorama_spec.js
@@ -5,7 +5,7 @@ const panorama = '.c-panorama';
 describe('panorama module', () => {
   beforeEach(() => {
     cy.server();
-    cy.route('/panorama/panoramas/*/adjacencies/?newest_in_range=true').as('getResults');
+    cy.route('/panorama/panoramas/*/adjacencies/?newest_in_range=true&mission_type=bi').as('getResults');
 
     // go to the homepage
     cy.visit('/');
@@ -95,7 +95,7 @@ describe('panorama module', () => {
 
   describe.only('user should be able to interact with the panorama', () => {
     it('should remember the state when closing the pano, and update to search results when clicked in map', () => {
-      const panoUrl = '/datasets/panorama/TMX7316010203-000714_pano_0001_002608?heading=-35.000000000000064&lagen=cGFubzox&lat=52.3734172850645&legenda=false&lng=4.8935938669686';
+      const panoUrl = '/datasets/panorama/TMX7316010203-000714_pano_0001_002608?heading=325&legenda=false&reference=03630000004153%2Cbag%2Copenbareruimte&reference=03630000004153%2Cbag%2Copenbareruimte';
       let newUrl;
 
       cy.defineGeoSearchRoutes();
@@ -114,19 +114,19 @@ describe('panorama module', () => {
 
       cy.wait('@getOpenbareRuimte');
       cy.wait('@getPanoThumbnail');
-      cy.get('img.c-panorama-thumbnail--img').should('exist').and('be.visible');
-      cy.get('h2.qa-title').should('exist').and('be.visible').contains('Leidsegracht');
-      cy.get('img.c-panorama-thumbnail--img').click();
+      cy.get('img.map-detail-result__header-pano').should('exist').and('be.visible');
+      cy.get('h2.map-detail-result__header-subtitle').should('exist').and('be.visible').contains('Leidsegracht');
+      cy.get('img.map-detail-result__header-pano').click();
 
       cy.wait('@getResults');
       cy.location().then((loc) => {
-        newUrl = loc.pathname + loc.search;
+        newUrl = loc.pathname + loc.search + '&reference=03630000004153%2Cbag%2Copenbareruimte';
         expect(newUrl).to.equal(panoUrl);
       });
 
       let largestButtonSize = 0;
       let largestButton;
-      cy.get('.qa-hotspot-rotation:visible').each((button) => {
+      cy.get('.qa-hotspot-rotation').each((button) => {
         // get largest (e.g. closest by) navigation button
         cy.wrap(button).should('have.css', 'width').then((width) => {
           if (parseInt(width.replace('px', ''), 10) > largestButtonSize) {
@@ -145,10 +145,10 @@ describe('panorama module', () => {
         expect(newUrl).not.to.equal(panoUrl);
       });
 
-      cy.get('button.c-panorama__close').click();
-      cy.get('img.c-panorama-thumbnail--img').should('exist').and('be.visible');
-      cy.get('h2.qa-title').should('exist').and('be.visible').contains('Leidsegracht');
-      cy.get('img.c-panorama-thumbnail--img').click();
+      cy.get('button.button-new__right').last().click();
+      cy.get('img.map-detail-result__header-pano').should('exist').and('be.visible');
+      cy.get('h2.map-detail-result__header-subtitle').should('exist').and('be.visible').contains('Leidsegracht');
+      cy.get('img.map-detail-result__header-pano').click();
 
       cy.get('.leaflet-container').click(20, 100);
 
@@ -158,11 +158,14 @@ describe('panorama module', () => {
         const thisUrl = loc.pathname + loc.hash;
         expect(thisUrl).not.to.equal(newUrl);
       });
-      cy.get('button.c-panorama__close').click();
+      cy.get('button.button-new__right').last().click();
 
-      cy.waitForGeoSearch();
-      cy.get('h1.o-header__title').contains('Resultaten').should('exist').and('be.visible');
-      cy.get('h2').contains('Openbare ruimte').should('exist').and('be.visible');
+      cy.wait('@getOpenbareRuimte');
+      cy.wait('@getPanoThumbnail');
+
+      // should show the openbareruimte again
+      cy.get('img.map-detail-result__header-pano').should('exist').and('be.visible');
+      cy.get('h2.map-detail-result__header-subtitle').should('exist').and('be.visible').contains('Leidsegracht');
     });
   });
 });


### PR DESCRIPTION
DP-6466: Always use bi as missiontype, even when showing the most recent panorama images. Fixed panorama e2e test