### PR TITLE
Remove unneeded z-indexs that prevented menu to be the top index

### DIFF
--- a/src/app/components/IconButton/IconButton.scss
+++ b/src/app/components/IconButton/IconButton.scss
@@ -1,4 +1,4 @@
-@import "../../../shared/styles/config";
+@import '../../../shared/styles/config';
 
 $icon-height: 24px;
 
@@ -12,7 +12,6 @@ $icon-height: 24px;
   position: absolute;
   right: $container-whitespace;
   top: $container-whitespace;
-  z-index: 150;
 
   &__left {
     left: $container-whitespace;
@@ -34,15 +33,14 @@ $icon-height: 24px;
   width: $icon-height;
 
   &--maximize {
-    @include icon-sprite("icon-maximize", $secondary-gray60, $primary-dark, $icon-height);
-
+    @include icon-sprite('icon-maximize', $secondary-gray60, $primary-dark, $icon-height);
   }
 
   &--minimize {
-    @include icon-sprite("icon-minimize", $secondary-gray60, $primary-dark, $icon-height);
+    @include icon-sprite('icon-minimize', $secondary-gray60, $primary-dark, $icon-height);
   }
 
   &--cross {
-    @include icon-sprite("icon-cross", $secondary-gray60, $primary-dark, 30px);
+    @include icon-sprite('icon-cross', $secondary-gray60, $primary-dark, 30px);
   }
 }

--- a/src/map/components/leaflet/assets/styles/_map.scss
+++ b/src/map/components/leaflet/assets/styles/_map.scss
@@ -41,8 +41,9 @@ $on-top-of-leaflet: 999;
   position: absolute;
   right: 0;
   top: 0;
-  transform: translateZ(0); //translateZ(0) is needed to fix a Firefox bug, see tg-1306 (black screen when scrolling)
-  z-index: $body-z-index;
+  transform: translateZ(
+    0
+  ); //translateZ(0) is needed to fix a Firefox bug, see tg-1306 (black screen when scrolling
 }
 
 .c-map__overlay-buttons {
@@ -53,7 +54,7 @@ $on-top-of-leaflet: 999;
 
 %overlay-button {
   float: left;
-  margin-right: $base-whitespace * .2;
+  margin-right: $base-whitespace * 0.2;
   z-index: $on-top-z-index;
 }
 
@@ -67,7 +68,8 @@ $on-top-of-leaflet: 999;
 .is-embed-preview {
   .c-map__leaflet {
     &:focus {
-      .c-map__focus-layer { // sass-lint:disable-line nesting-depth
+      .c-map__focus-layer {
+        // sass-lint:disable-line nesting-depth
         border: 1px solid $primary-dark;
       }
     }


### PR DESCRIPTION
Changed line 15 in `src/app/components/IconButton/IconButton.scss` and line 45 in `src/map/components/leaflet/assets/styles/_map.scss`.

Other changes are due to adding `prettier` in `lint-staged` earlier on