### PR TITLE
Also take the search term when the new editorial tabs are used for se…

### DIFF
--- a/src/header/ducks/auto-suggest/auto-suggest.js
+++ b/src/header/ducks/auto-suggest/auto-suggest.js
@@ -62,8 +62,11 @@ export default function AutoSuggestReducer(state = initialState, action) {
         typedQuery: enrichedState.typedQuery,
       }
 
+    // Sets the typedQuery based on the selected tab
     case routing.dataSearchQuery.type:
     case routing.datasetSearch.type:
+    case routing.articleSearch.type:
+    case routing.publicationSearch.type:
       return {
         ...enrichedState,
         typedQuery: get(action, `meta.query[${PARAMETERS.QUERY}]`),

--- a/src/header/ducks/auto-suggest/auto-suggest.test.js
+++ b/src/header/ducks/auto-suggest/auto-suggest.test.js
@@ -90,16 +90,25 @@ describe('AutoSuggestReducer Reducer', () => {
   })
 
   it('should set the query from meta data', () => {
-    expect(
-      reducer(initialState, {
-        type: routing.dataSearchQuery.type,
-        meta: {
-          query: { term: 'foo' },
-        },
-      }),
-    ).toEqual({
-      ...initialState,
-      typedQuery: 'foo',
+    const tabRoutes = [
+      routing.dataSearchQuery.type,
+      routing.datasetSearch.type,
+      routing.articleSearch.type,
+      routing.publicationSearch.type,
+    ]
+
+    tabRoutes.forEach(route => {
+      expect(
+        reducer(initialState, {
+          type: route,
+          meta: {
+            query: { term: 'foo' },
+          },
+        }),
+      ).toEqual({
+        ...initialState,
+        typedQuery: 'foo',
+      })
     })
   })
 })


### PR DESCRIPTION
…arching