### PR TITLE
Add all query types to search overview page to show missing types

### DIFF
--- a/src/app/pages/SearchPage/config.js
+++ b/src/app/pages/SearchPage/config.js
@@ -48,7 +48,7 @@ export const EDITORIAL_SEARCH_PAGES = [
 
 export default {
   [routing.search.page]: {
-    resolver: ['dataSearch', 'datasetSearch', 'articleSearch'],
+    resolver: Object.values(QUERY_TYPES),
     to: toSearch,
     query: searchQuery,
     label: routing.search.title,


### PR DESCRIPTION
Fixes: https://datapunt.atlassian.net/browse/DI-322