### PR TITLE
Fix the search scenario when a number is used as search query

### DIFF
--- a/src/app/pages/SearchPage/SearchPage.jsx
+++ b/src/app/pages/SearchPage/SearchPage.jsx
@@ -114,6 +114,7 @@ const SearchPage = ({ currentPage, query }) => {
 
           <SearchPageResults
             {...{
+              hasQuery,
               query,
               errors,
               fetching: initialLoading,

--- a/src/app/pages/SearchPage/SearchPageDucks.ts
+++ b/src/app/pages/SearchPage/SearchPageDucks.ts
@@ -93,7 +93,8 @@ export default function reducer(state = initialState, action: SearchPageAction):
 
 type StoreValue = { [REDUCER_KEY]: SearchPageState }
 
-export const getQuery = ({ [REDUCER_KEY]: { query } }: StoreValue) => query
+// The query should always be a string
+export const getQuery = ({ [REDUCER_KEY]: { query } }: StoreValue) => query && query.toString()
 
 export const getSort = ({ [REDUCER_KEY]: { sort } }: StoreValue) => sort
 export const getPage = ({ [REDUCER_KEY]: { page } }: StoreValue) => page

--- a/src/app/pages/SearchPage/SearchPageResults.jsx
+++ b/src/app/pages/SearchPage/SearchPageResults.jsx
@@ -99,13 +99,12 @@ const SearchPageResults = ({
   sort,
   page,
   pageInfo,
+  hasQuery,
 }) => {
   const dispatch = useDispatch()
   const allResultsPageActive = currentPage === PAGES.SEARCH
 
   const formatTitle = (label, count = null) => {
-    const hasQuery = query.trim().length > 0
-
     // Handle an empty result.
     if (count === 0) {
       return hasQuery ? `Geen resultaten met '${query}'` : 'Geen resultaten'


### PR DESCRIPTION
The query should always be a string