### PR TITLE
Disable URL state updates for legend items

### DIFF
--- a/src/app/pages/MapPage/MapContainer.tsx
+++ b/src/app/pages/MapPage/MapContainer.tsx
@@ -12,7 +12,6 @@ import getState from '../../../shared/services/redux/get-state'
 import PARAMETERS from '../../../store/parameters'
 import {
   decodeBounds,
-  decodeLayers,
   decodeLocation,
   encodeBounds,
   encodeLayers,
@@ -278,7 +277,8 @@ const MapContextProvider: React.FC<MapContextProps> = ({ children }) => {
 
   React.useEffect(() => {
     if (baseLayer) setActiveBaseLayer(baseLayer)
-    if (activeMapLayers) setActiveMapLayers(decodeLayers(activeMapLayers))
+    // TODO: Find a better way to keep track of state changes
+    // if (activeMapLayers) setActiveMapLayers(decodeLayers(activeMapLayers))
     // @ts-ignore fix the destruction of the location from the url
     if (location) setLocation(decodeLocation(location))
     if (detailUrl) setDetailUrl(detailUrl)

--- a/src/app/pages/MapPage/MapPage.tsx
+++ b/src/app/pages/MapPage/MapPage.tsx
@@ -18,12 +18,12 @@ import { toMap } from '../../../store/redux-first-router/actions'
 import NotificationLevel from '../../models/notification'
 import DrawContent from './Components/DrawContent'
 import GeoJSON from './Components/GeoJSON'
-import MapLegend from './Components/MapLegend'
 import PointSearchMarker from './Components/PointSearchMarker'
 import ViewerContainer from './Components/ViewerContainer'
 import DataSelectionProvider from './DataSelectionProvider'
 import MapContext from './MapContext'
 import DetailPanel from './panels/DetailPanel'
+import LegendPanel from './panels/LegendPanel'
 import PointSearchPanel from './panels/PointSearchPanel'
 import { Overlay, SnapPoint } from './types'
 import handleMapClick from './utils/handleMapClick'
@@ -152,7 +152,7 @@ const MapPage: React.FC = () => {
                   />
                 )}
                 {currentOverlay === Overlay.Legend && (
-                  <MapLegend
+                  <LegendPanel
                     stackOrder={3}
                     animate
                     onClose={() => {
@@ -171,7 +171,7 @@ const MapPage: React.FC = () => {
                 )}
                 {detailUrl && <DetailPanel detailUrl={detailUrl} />}
                 <DrawContent {...{ showDrawTool, currentOverlay, setShowDrawTool }} />
-                {!detailUrl && <MapLegend />}
+                {!detailUrl && <LegendPanel />}
               </MapPanelOrDrawer>
               <ViewerContainer
                 {...{

--- a/src/app/pages/MapPage/panels/LegendPanel.tsx
+++ b/src/app/pages/MapPage/panels/LegendPanel.tsx
@@ -27,7 +27,7 @@ const StyledMapPanelContent = styled(MapPanelContent)`
   }
 `
 
-const MapLegend: React.FC = ({ ...otherProps }) => {
+const LegendPanel: React.FC = ({ ...otherProps }) => {
   const {
     panelLayers,
     activeMapLayers,
@@ -76,4 +76,4 @@ const MapLegend: React.FC = ({ ...otherProps }) => {
   )
 }
 
-export default MapLegend
+export default LegendPanel


### PR DESCRIPTION
This prevents the application from ending up in a loop where the legend items are cleared every time they are clicked. Also moves the legend panel into a new file.