### PR TITLE
Added word-break: break-word rule for title in EditorialCard to preve…

### DIFF
--- a/src/app/components/EditorialCard/EditorialCard.tsx
+++ b/src/app/components/EditorialCard/EditorialCard.tsx
@@ -105,6 +105,7 @@ const StyledHeading = styled(Heading)<{ compact: boolean }>`
   width: fit-content;
   display: inline-block;
   font-weight: bold;
+  word-break: break-word;
   ${({ compact }) =>
     compact &&
     css`


### PR DESCRIPTION
…nt overflow