### PR TITLE
Remove page margin for print layout

### DIFF
--- a/src/shared/styles/utilities/_print.scss
+++ b/src/shared/styles/utilities/_print.scss
@@ -18,5 +18,5 @@
 }
 
 @page {
-  margin: 0.5in;
+  margin: 0;
 }


### PR DESCRIPTION
Prevents certain elements such as tables from flowing outside of the page borders.