### PR TITLE
Use 'generatePath' to format autosuggest paths

### DIFF
--- a/src/app/AppBody.jsx
+++ b/src/app/AppBody.jsx
@@ -3,7 +3,7 @@ import { useMatomo } from '@datapunt/matomo-tracker-react'
 import PropTypes from 'prop-types'
 import React, { Suspense } from 'react'
 import { Helmet } from 'react-helmet'
-import { Route, Switch } from 'react-router'
+import { generatePath, Route, Switch } from 'react-router'
 import { Link as RouterLink } from 'react-router-dom'
 import styled from 'styled-components'
 import { IDS } from '../shared/config/config'
@@ -13,7 +13,7 @@ import LoadingSpinner from './components/LoadingSpinner/LoadingSpinner'
 import { FeedbackModal } from './components/Modal'
 import NotificationAlert from './components/NotificationAlert/NotificationAlert'
 import PAGES from './pages'
-import { getRoute, mapSearchPagePaths, mapSplitPagePaths, routing } from './routes'
+import { mapSearchPagePaths, mapSplitPagePaths, routing } from './routes'
 import isIE from './utils/isIE'
 
 const HomePage = React.lazy(() => import(/* webpackChunkName: "HomePage" */ './pages/HomePage'))
@@ -98,11 +98,10 @@ const AppBody = ({ visibilityError, bodyClasses, hasGrid, currentPage, embedPrev
                 </Paragraph>{' '}
                 <Link
                   as={RouterLink}
-                  to={getRoute(
-                    routing.articleDetail.path,
-                    'internet-explorer-binnenkort-niet-meer-ondersteund',
-                    '11206c96-91d6-4f6a-9666-68e577797865',
-                  )}
+                  to={generatePath(routing.articleDetail.path, {
+                    slug: 'internet-explorer-binnenkort-niet-meer-ondersteund',
+                    id: '11206c96-91d6-4f6a-9666-68e577797865',
+                  })}
                   inList
                   darkBackground
                 >

--- a/src/app/routes.js
+++ b/src/app/routes.js
@@ -190,14 +190,6 @@ const routes = Object.keys(routing).reduce((acc, key) => {
   return acc
 }, {})
 
-export function getRoute(path, ...args) {
-  let count = -1
-  return path.replace(/:[a-zA-Z?]+/g, (match) => {
-    count += 1
-    return args[count] !== undefined ? args[count] : match
-  })
-}
-
 export const mapSearchPagePaths = [
   routing.search.path,
   routing.dataSearch.path,

--- a/src/header/components/auto-suggest/AutoSuggestItem.tsx
+++ b/src/header/components/auto-suggest/AutoSuggestItem.tsx
@@ -3,9 +3,9 @@ import escapeStringRegexp from 'escape-string-regexp'
 import { LocationDescriptorObject } from 'history'
 import React, { useMemo } from 'react'
 import { useSelector } from 'react-redux'
-import { Link } from 'react-router-dom'
+import { generatePath, Link } from 'react-router-dom'
 import SearchType from '../../../app/pages/SearchPage/constants'
-import { getRoute, routing } from '../../../app/routes'
+import { routing } from '../../../app/routes'
 import useSlug from '../../../app/utils/useSlug'
 import { CmsType } from '../../../shared/config/cms.config'
 import { getViewMode, VIEW_MODE } from '../../../shared/ducks/ui/ui'
@@ -39,13 +39,13 @@ const AutoSuggestItem: React.FC<AutoSuggestItemProps> = ({
   ) => {
     switch (type) {
       case CmsType.Article:
-        return getRoute(routing.articleDetail.path, slug, id)
+        return generatePath(routing.articleDetail.path, { slug, id })
       case CmsType.Collection:
-        return getRoute(routing.collectionDetail.path, slug, id)
+        return generatePath(routing.collectionDetail.path, { slug, id })
       case CmsType.Publication:
-        return getRoute(routing.publicationDetail.path, slug, id)
+        return generatePath(routing.publicationDetail.path, { slug, id })
       case CmsType.Special:
-        return getRoute(routing.specialDetail.path, subType, slug, id)
+        return generatePath(routing.specialDetail.path, { type: subType, slug, id })
       default:
         throw new Error(`Unable to open editorial suggestion, unknown type '${type}'.`)
     }
@@ -57,7 +57,7 @@ const AutoSuggestItem: React.FC<AutoSuggestItemProps> = ({
       const slug = useSlug(suggestion.label)
 
       return {
-        pathname: getRoute(routing.datasetDetail.path, { id, slug }),
+        pathname: generatePath(routing.datasetDetail.path, { id, slug }),
         search: new URLSearchParams({
           [PARAMETERS.QUERY]: `${inputValue}`,
         }).toString(),
@@ -103,9 +103,10 @@ const AutoSuggestItem: React.FC<AutoSuggestItemProps> = ({
     }
 
     const { type, subtype, id } = getDetailPageData(suggestion.uri)
+
     // suggestion.category TRACK
     return {
-      pathname: getRoute(routing.dataDetail.path, type, subtype, `id${id}`),
+      pathname: generatePath(routing.dataDetail.path, { type, subtype, id: `id${id}` }),
       search: new URLSearchParams({
         [PARAMETERS.VIEW]: view,
         [PARAMETERS.QUERY]: `${inputValue}`,


### PR DESCRIPTION
Resolves issues where some paths are not correctly resolved resulting in routing to a 404 page.