### PR TITLE
(Fix) Split error

### DIFF
--- a/src/panorama/containers/PanoramaContainer.jsx
+++ b/src/panorama/containers/PanoramaContainer.jsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import debounce from 'lodash.debounce'
+import throttle from 'lodash.throttle'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
@@ -40,7 +40,7 @@ class PanoramaContainer extends React.Component {
     this.hotspotClickHandler = this.hotspotClickHandler.bind(this)
     this.loadPanoramaScene = this.loadPanoramaScene.bind(this)
 
-    this.updateOrientationThrottled = debounce(this.updateOrientation, 300, {
+    this.updateOrientationThrottled = throttle(this.updateOrientation, 300, {
       leading: true,
       trailing: true,
     })

--- a/src/panorama/containers/PanoramaContainer.jsx
+++ b/src/panorama/containers/PanoramaContainer.jsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import throttle from 'lodash.throttle'
+import debounce from 'lodash.debounce'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
@@ -40,7 +40,7 @@ class PanoramaContainer extends React.Component {
     this.hotspotClickHandler = this.hotspotClickHandler.bind(this)
     this.loadPanoramaScene = this.loadPanoramaScene.bind(this)
 
-    this.updateOrientationThrottled = throttle(this.updateOrientation, 300, {
+    this.updateOrientationThrottled = debounce(this.updateOrientation, 300, {
       leading: true,
       trailing: true,
     })

--- a/src/store/queryParameters.js
+++ b/src/store/queryParameters.js
@@ -301,7 +301,7 @@ export default paramsRegistry
       {
         defaultValue: panoramaInitialState.detailReference,
         decode: (val) =>
-          val && val.length ? val.split(',') : panoramaInitialState.detailReference,
+          val?.length > 0 && val?.split ? val.split(',') : panoramaInitialState.detailReference,
         selector: getDetailReference,
         encode: (selectorResult) =>
           selectorResult.length ? selectorResult.join() : panoramaInitialState.detailReference,


### PR DESCRIPTION
This PR fixes an error that occurred when navigating from any detail page (nummeraanduiding, adres) to a panorama page. An entry in `queryParameters` got an array of string instead of a single string as parameter which threw an error, because an array doesn't have the `split` function in its prototype.
