### PR TITLE
[DI-1190] Buurten links fix

### DIFF
--- a/src/store/middleware/addMetaToRoutesMiddleware.js
+++ b/src/store/middleware/addMetaToRoutesMiddleware.js
@@ -8,13 +8,13 @@ const addMetaToRoutesMiddleware = ({ getState }) => (next) => (action) => {
       nrOfRoutesDispatched = 0
     }
 
-    const firstAction = nrOfRoutesDispatched === 0
+    const isFirstAction = nrOfRoutesDispatched === 0
 
     nrOfRoutesDispatched += 1
     const nextAction = action
     const meta = {
       ...(nextAction && nextAction.meta ? { ...nextAction.meta } : {}),
-      ...(firstAction ? { firstAction } : {}),
+      ...(isFirstAction ? { isFirstAction } : {}),
     }
     return next({
       ...nextAction,

--- a/src/store/middleware/addMetaToRoutesMiddleware.test.js
+++ b/src/store/middleware/addMetaToRoutesMiddleware.test.js
@@ -27,16 +27,16 @@ describe('addMetaToRoutesMiddleware', () => {
     expect(next).toHaveBeenCalledWith(action)
   })
 
-  it("should add firstAction to the action's meta", () => {
+  it("should add isFirstAction to the action's meta", () => {
     const action = { type: 'some type' }
     addMetaToRoutesMiddleware(store)(next)(action)
     expect(next).toHaveBeenCalledWith({
       ...action,
-      meta: { firstAction: true },
+      meta: { isFirstAction: true },
     })
   })
 
-  it("should not add firstAction to the action's meta if locationType is equal to action.type are the same", () => {
+  it("should not add isFirstAction to the action's meta if locationType is equal to action.type are the same", () => {
     setState({
       location: {
         type: 'some type',

--- a/src/store/middleware/matomo/__snapshots__/trackEvents.test.js.snap
+++ b/src/store/middleware/matomo/__snapshots__/trackEvents.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`trackEvents matches the snapshot 1`] = `
+Object {
+  "@@redux-first-router/NOT_FOUND": [Function],
+  "MAP_SET_DRAWING_MODE": [Function],
+  "SET_MAP_BASE_LAYER": [Function],
+  "SET_MAP_CLICK_LOCATION": [Function],
+  "TOGGLE_MAP_EMBED": [Function],
+  "atlasRouter/DATA_DETAIL": [Function],
+  "filter/ADD_FILTER": [Function],
+  "filter/REMOVE_FILTER": [Function],
+  "header/CLOSE_MODAL": [Function],
+  "header/REPORT_FEEDBACK_REQUEST": [Function],
+  "header/REPORT_PROBLEM_REQUEST": [Function],
+  "panorama/CLOSE_PANORAMA": [Function],
+  "panorama/FETCH_PANORAMA_HOTSPOT_REQUEST": [Function],
+  "panorama/FETCH_PANORAMA_REQUEST_EXTERNAL": [Function],
+  "panorama/FETCH_PANORAMA_REQUEST_TOGGLE": [Function],
+  "ui/HIDE_EMBED_PREVIEW": [Function],
+  "ui/HIDE_PRINT": [Function],
+  "ui/SET_VIEW_MODE": [Function],
+  "ui/SHARE_PAGE": [Function],
+  "ui/SHOW_EMBED_PREVIEW": [Function],
+  "ui/SHOW_PRINT": [Function],
+  "user/AUTHENTICATE_USER_REQUEST": [Function],
+  "user/AUTHENTICATE_USER_SUCCESS": [Function],
+}
+`;

--- a/src/store/middleware/matomo/matomoMiddleware.js
+++ b/src/store/middleware/matomo/matomoMiddleware.js
@@ -20,7 +20,7 @@ const matomoMiddleware = ({ getState }) => (next) => (action) => {
   }
 
   if (actionsToMatomo.length) {
-    const { firstAction, location, query, tracking } = action.meta || {}
+    const { isFirstAction, location, query, tracking } = action.meta || {}
     const state = getState()
 
     const { href } = window.location
@@ -40,7 +40,7 @@ const matomoMiddleware = ({ getState }) => (next) => (action) => {
         matomoInstance.track({
           data: matomoAction({
             tracking,
-            firstAction,
+            isFirstAction,
             query,
             state,
             title: titleForMatomo,

--- a/src/store/middleware/matomo/trackEvents.js
+++ b/src/store/middleware/matomo/trackEvents.js
@@ -43,45 +43,60 @@ import {
   isPanoPage,
 } from '../../redux-first-router/selectors'
 
+export const TRACK_ACTION_NAVIGATION = 'navigation'
+export const TRACK_CATEGORY_AUTO_SUGGEST = 'auto-suggest'
+export const TRACK_NAME_ENLARGE_DETAIL_MAP = 'detail-kaart-vergroten'
+export const TRACK_NAME_FULL_DETAIL = 'detail-volledig-weergeven'
+export const TRACK_NAME_LEAVE_PANO = 'panorama-verlaten'
+
 /* istanbul ignore next */
 const trackEvents = {
   // NAVIGATION
   // NAVIGATION -> NAVIGATE TO DATA DETAIL
-  [routing.dataDetail.type]: function trackDataDetail({ firstAction, query, tracking, state }) {
-    // eslint-disable-next-line no-nested-ternary
-    return tracking && tracking.event === 'auto-suggest'
-      ? [
-          MATOMO_CONSTANTS.TRACK_EVENT,
-          'auto-suggest', // NAVIGATION -> SELECT AUTOSUGGEST OPTION
-          tracking.category,
-          tracking.query,
-        ]
-      : // eslint-disable-next-line no-nested-ternary
-      getViewMode(state) === VIEW_MODE.MAP && query[PARAMETERS.VIEW] === undefined
-      ? [
-          MATOMO_CONSTANTS.TRACK_EVENT,
-          'navigation', // NAVIGATION -> CLICK TOGGLE FULLSCREEN FROM MAP
-          'detail-volledig-weergeven',
-          null,
-        ]
-      : // eslint-disable-next-line no-nested-ternary
-      !firstAction &&
-        getViewMode(state) === VIEW_MODE.SPLIT &&
-        query[PARAMETERS.VIEW] === VIEW_MODE.MAP
-      ? [
-          MATOMO_CONSTANTS.TRACK_EVENT,
-          'navigation', // NAVIGATION -> CLICK TOGGLE FULLSCREEN FROM SPLITSCREEN
-          'detail-kaart-vergroten',
-          null,
-        ]
-      : isPanoPage(state)
-      ? [
-          MATOMO_CONSTANTS.TRACK_EVENT,
-          'navigation', // NAVIGATION -> CLICK CLOSE FROM PANORAMA
-          'panorama-verlaten',
-          null,
-        ]
-      : []
+  [routing.dataDetail.type]: function trackDataDetail({ isFirstAction, query, tracking, state }) {
+    if (tracking?.event === 'auto-suggest') {
+      return [
+        MATOMO_CONSTANTS.TRACK_EVENT,
+        'auto-suggest', // NAVIGATION -> SELECT AUTOSUGGEST OPTION
+        tracking.category,
+        tracking.query,
+      ]
+    }
+
+    const viewMode = getViewMode(state)
+
+    if (viewMode === VIEW_MODE.MAP && query?.[PARAMETERS.VIEW] === undefined) {
+      return [
+        MATOMO_CONSTANTS.TRACK_EVENT,
+        'navigation', // NAVIGATION -> CLICK TOGGLE FULLSCREEN FROM MAP
+        'detail-volledig-weergeven',
+        null,
+      ]
+    }
+
+    if (
+      !isFirstAction &&
+      viewMode === VIEW_MODE.SPLIT &&
+      query?.[PARAMETERS.VIEW] === VIEW_MODE.MAP
+    ) {
+      return [
+        MATOMO_CONSTANTS.TRACK_EVENT,
+        'navigation', // NAVIGATION -> CLICK TOGGLE FULLSCREEN FROM SPLITSCREEN
+        'detail-kaart-vergroten',
+        null,
+      ]
+    }
+
+    if (isPanoPage(state)) {
+      return [
+        MATOMO_CONSTANTS.TRACK_EVENT,
+        'navigation', // NAVIGATION -> CLICK CLOSE FROM PANORAMA
+        'panorama-verlaten',
+        null,
+      ]
+    }
+
+    return []
   },
   // NAVIGATION -> CLICK CLOSE FROM PANORAMA
   [CLOSE_PANORAMA]: () => [MATOMO_CONSTANTS.TRACK_EVENT, 'navigation', 'panorama-verlaten', null],
@@ -90,14 +105,14 @@ const trackEvents = {
   // NAVIGATION -> CLOSE EMBED VIEW
   [HIDE_EMBED_PREVIEW]: () => [
     MATOMO_CONSTANTS.TRACK_EVENT,
-    'navigation',
+    TRACK_ACTION_NAVIGATION,
     'embedversie-verlaten',
     null,
   ],
   // NAVIGATION -> TOGGLE FROM EMBEDDED MAP
   [TOGGLE_MAP_EMBED]: () => [
     MATOMO_CONSTANTS.TRACK_EVENT,
-    'navigation',
+    TRACK_ACTION_NAVIGATION,
     'embedkaart-naar-portaal',
     null,
   ],
@@ -108,7 +123,7 @@ const trackEvents = {
       case PAGES.DATA_SEARCH_GEO:
         return [
           MATOMO_CONSTANTS.TRACK_EVENT,
-          'navigation', // NAVIGATION -> CLICK TOGGLE FULLSCREEN FROM MAP Or SPLITSCREEN
+          TRACK_ACTION_NAVIGATION, // NAVIGATION -> CLICK TOGGLE FULLSCREEN FROM MAP Or SPLITSCREEN
           `georesultaten-${viewMode === VIEW_MODE.MAP ? 'volledig-weergeven' : 'kaart-vergroten'}`,
           null,
         ]
@@ -118,7 +133,7 @@ const trackEvents = {
         if (typeof tracking === 'boolean') {
           view = viewMode === VIEW_MODE.MAP ? 'kaart-verkleinen' : 'kaart-vergroten'
         }
-        return [MATOMO_CONSTANTS.TRACK_EVENT, 'navigation', `panorama-${view}`, null]
+        return [MATOMO_CONSTANTS.TRACK_EVENT, TRACK_ACTION_NAVIGATION, `panorama-${view}`, null]
       }
 
       case PAGES.ADDRESSES:
@@ -128,13 +143,13 @@ const trackEvents = {
         if (typeof tracking === 'boolean') {
           view = viewMode === VIEW_MODE.MAP ? 'kaart-verkleinen' : 'kaart-vergroten'
         }
-        return [MATOMO_CONSTANTS.TRACK_EVENT, 'navigation', `dataselectie-${view}`, null]
+        return [MATOMO_CONSTANTS.TRACK_EVENT, TRACK_ACTION_NAVIGATION, `dataselectie-${view}`, null]
       }
 
       default:
         return [
           MATOMO_CONSTANTS.TRACK_EVENT,
-          'navigation',
+          TRACK_ACTION_NAVIGATION,
           `detail-${viewMode === VIEW_MODE.MAP ? 'volledig-weergeven' : 'kaart-vergroten'}`,
           null,
         ]

--- a/src/store/middleware/matomo/trackEvents.test.js
+++ b/src/store/middleware/matomo/trackEvents.test.js
@@ -1,0 +1,93 @@
+import { MATOMO_CONSTANTS } from '../../../app/matomo'
+import PAGES from '../../../app/pages'
+import { VIEW_MODE } from '../../../shared/ducks/ui/ui'
+import PARAMETERS from '../../parameters'
+import { routing, ROUTER_NAMESPACE } from '../../../app/routes'
+
+import trackEvents, {
+  TRACK_ACTION_NAVIGATION,
+  TRACK_CATEGORY_AUTO_SUGGEST,
+  TRACK_NAME_ENLARGE_DETAIL_MAP,
+  TRACK_NAME_FULL_DETAIL,
+  TRACK_NAME_LEAVE_PANO,
+} from './trackEvents'
+
+describe('trackEvents', () => {
+  it('matches the snapshot', () => {
+    // snapshots generally don't offer much value, but in this case, since the value of trackEvents is an object with
+    // keys that are specific to the sections in the application that need to be tracked, it's worthwhile to generate
+    // a snaphot of the entire object so that any changes will be more easily picked up
+    expect(trackEvents).toMatchSnapshot()
+  })
+
+  describe('data detail tracking', () => {
+    const dataDetailTrackingFunc = trackEvents[routing.dataDetail.type]
+    const trackingPayload = { state: { ui: { viewMode: undefined } } }
+
+    it('should return an empty array when the view mode has not been set', () => {
+      expect(dataDetailTrackingFunc(trackingPayload)).toEqual([])
+      expect(dataDetailTrackingFunc({ ...trackingPayload, tracking: null })).toEqual([])
+    })
+
+    it('should return data for the auto-suggest event', () => {
+      const trackingObj = { event: TRACK_CATEGORY_AUTO_SUGGEST, category: 'foo', query: 'bar' }
+
+      expect(dataDetailTrackingFunc({ ...trackingPayload, tracking: trackingObj })).toEqual([
+        MATOMO_CONSTANTS.TRACK_EVENT,
+        TRACK_CATEGORY_AUTO_SUGGEST,
+        trackingObj.category,
+        trackingObj.query,
+      ])
+
+      expect(
+        dataDetailTrackingFunc({ ...trackingPayload, tracking: { ...trackingObj, event: 'foo' } }),
+      ).toEqual([])
+    })
+
+    it('should return data for when the map is the view mode', () => {
+      const payload = { state: { ui: { viewMode: VIEW_MODE.MAP } } }
+
+      expect(dataDetailTrackingFunc(payload)).toEqual([
+        MATOMO_CONSTANTS.TRACK_EVENT,
+        TRACK_ACTION_NAVIGATION,
+        TRACK_NAME_FULL_DETAIL,
+        null,
+      ])
+    })
+
+    it('should return data for when split is the view mode', () => {
+      const payload = {
+        state: { ui: { viewMode: VIEW_MODE.SPLIT } },
+        isFirstAction: false,
+        query: { [PARAMETERS.VIEW]: VIEW_MODE.MAP },
+      }
+
+      expect(dataDetailTrackingFunc(payload)).toEqual([
+        MATOMO_CONSTANTS.TRACK_EVENT,
+        TRACK_ACTION_NAVIGATION,
+        TRACK_NAME_ENLARGE_DETAIL_MAP,
+        null,
+      ])
+
+      expect(dataDetailTrackingFunc({ ...payload, isFirstAction: true })).toEqual([])
+      expect(dataDetailTrackingFunc({ ...payload, query: {} })).toEqual([])
+      expect(dataDetailTrackingFunc({ ...payload, query: undefined })).toEqual([])
+    })
+
+    it('should return data for when page is a panoramo page', () => {
+      const payload = {
+        state: {
+          ui: { viewMode: VIEW_MODE.SPLIT },
+          location: { type: `${ROUTER_NAMESPACE}/${PAGES.PANORAMA}` },
+        },
+      }
+
+      expect(dataDetailTrackingFunc(payload)).toEqual([
+        MATOMO_CONSTANTS.TRACK_EVENT,
+        TRACK_ACTION_NAVIGATION,
+        TRACK_NAME_LEAVE_PANO,
+        null,
+      ])
+    })
+  })
+})

--- a/src/store/middleware/matomo/trackViews.js
+++ b/src/store/middleware/matomo/trackViews.js
@@ -6,18 +6,18 @@ import { isDatasetDetailPage } from '../../redux-first-router/selectors'
 
 let views = Object.entries(routing).reduce((acc, [, value]) => ({
   ...acc,
-  [value.type]: function trackView({ firstAction = null, query = {}, href, title }) {
-    return firstAction || !!query.print ? [MATOMO_CONSTANTS.TRACK_VIEW, title, href, null] : []
+  [value.type]: function trackView({ isFirstAction = null, query = {}, href, title }) {
+    return isFirstAction || !!query.print ? [MATOMO_CONSTANTS.TRACK_VIEW, title, href, null] : []
   },
 }))
 
 views = {
   ...views,
-  [routing.home.type]: function trackView({ firstAction = null, query = {}, href, title }) {
-    return firstAction || !!query.print ? [MATOMO_CONSTANTS.TRACK_VIEW, title, href, null] : []
+  [routing.home.type]: function trackView({ isFirstAction = null, query = {}, href, title }) {
+    return isFirstAction || !!query.print ? [MATOMO_CONSTANTS.TRACK_VIEW, title, href, null] : []
   },
-  [routing.data.type]: function trackView({ firstAction = null, query = {}, href, title }) {
-    return firstAction || !!query.print
+  [routing.data.type]: function trackView({ isFirstAction = null, query = {}, href, title }) {
+    return isFirstAction || !!query.print
       ? [
           MATOMO_CONSTANTS.TRACK_VIEW,
           title, // PAGEVIEW -> MAP
@@ -27,7 +27,7 @@ views = {
       : []
   },
   [routing.dataDetail.type]: function trackView({
-    firstAction = null,
+    isFirstAction = null,
     query = {},
     href,
     title,
@@ -35,14 +35,14 @@ views = {
     tracking,
   }) {
     // eslint-disable-next-line no-nested-ternary
-    return !firstAction && tracking && tracking.id !== getDetail(state).id
+    return !isFirstAction && tracking && tracking.id !== getDetail(state).id
       ? [
           MATOMO_CONSTANTS.TRACK_VIEW,
           title, // PAGEVIEW -> DETAIL VIEW CLICK THROUGH VIEWS
           href,
           null,
         ]
-      : firstAction || !!query.print
+      : isFirstAction || !!query.print
       ? [
           MATOMO_CONSTANTS.TRACK_VIEW,
           title, // PAGEVIEW -> DETAIL VIEW INITIAL LOAD

--- a/src/store/redux-first-router/routeSaga.js
+++ b/src/store/redux-first-router/routeSaga.js
@@ -18,8 +18,8 @@ const routeSagaMapping = [
 
 const yieldOnFirstAction = (sideEffect) =>
   function* gen(action) {
-    const { skipSaga, firstAction, forceSaga } = action.meta || {}
-    if (!skipSaga && (firstAction || forceSaga)) {
+    const { skipSaga, isFirstAction, forceSaga } = action.meta || {}
+    if (!skipSaga && (isFirstAction || forceSaga)) {
       yield call(sideEffect, action)
     }
   }


### PR DESCRIPTION
This PR fixes an issue where an error would be thrown whenever a link was clicked for which the Matomo data required a prop `modus` to be present in the `query` object. Since the check for that prop was too rigid, not taking into account that `query` could also be not provided, error were thrown and navigation was prevented.

In addition to the fix, this PR also  renames the prop `firstAction` to `isFirstAction`, since it's a boolean value. Also, a deeply nested ternary condition inside the `trackEvents` script has been replaced with a more readable construct. In order to ensure that the replacement didn't break anything, tests were written prior to refactoring.