### PR TITLE
(Chore) GitHub actions adjustments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,3 @@ jobs:
 
       - name: Run ${{ matrix.job }}
         run: npm run ${{ matrix.job }}
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v1
-        if: matrix.job == 'test'
-        with:
-          name: coverage-report
-          path: coverage/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,6 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - name: Setup Node 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.18
-
       - name: install
         run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: install
         run: npm ci
 
-     - name: Run ${{ matrix.job }}
+      - name: Run ${{ matrix.job }}
         run: npm run ${{ matrix.job }}
 
       - name: Upload coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
       - master
       - develop
   pull_request:
-    branches:
-      - master
-      - develop
 
 jobs:
   build:
@@ -18,6 +15,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
+        job: [lint, test, build]
 
     steps:
       - uses: actions/checkout@v2
@@ -25,6 +23,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
       - name: Cache node modules
         uses: actions/cache@v2
         env:
@@ -37,11 +36,21 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
+      - name: Setup Node 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.18
+
       - name: install
-        run: npm install
-      - name: lint
-        run: npm run lint
-      - name: test
-        run: npm test
-      - name: build
-        run: npm run build
+        run: npm ci
+
+     - name: Run ${{ matrix.job }}
+        run: npm run ${{ matrix.job }}
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v1
+        if: matrix.job == 'test'
+        with:
+          name: coverage-report
+          path: coverage/


### PR DESCRIPTION
This PR:
- Makes sure that Github actions are run on all PRs, regardless of base branch
- Splits the action into multiple, separate, actions. It runs the actions in parallel and it allows us to see which individual action failed and will show up like so in a PR:
![Screenshot 2020-10-12 at 07 58 27](https://user-images.githubusercontent.com/1062191/95710333-bbacf480-0c60-11eb-8bda-39afd12af5d8.png)

- Generates a separate artifact for the test coverage