### PR TITLE
(Chore) Removes pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,7 +229,6 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "concurrently \"npm run test:jest -- --bail\" \"npm run test:karma\"",
       "pre-commit": "lint-staged",
       "post-merge": "./scripts/post-merge.sh"
     }


### PR DESCRIPTION
This PR removes the pre-push hook that runs test prior to finishing a `git push`. The hook always fails, because of insufficient test coverage. The strategy of breaking on coverage should be determined first. Until then, the pre-push hook shouldn't be limiting.