### PR TITLE
[DI-1190] Fix for links in detail panel

### DIFF
--- a/src/map/services/map-services.config.ts
+++ b/src/map/services/map-services.config.ts
@@ -221,7 +221,7 @@ const getShowInTableBlock = (filters: {
     links: [
       {
         to: {
-          pathname: config[DataSelectionType.BAG].path,
+          pathname: config[DataSelectionType.HR].path,
           search: `${PARAMETERS.VIEW}=volledig&${PARAMETERS.FILTERS}={"${filters.key}":"${filters.value}"}`,
         },
         title: 'In tabel weergeven',
@@ -239,7 +239,7 @@ const getShowInTableBlock = (filters: {
     links: [
       {
         to: {
-          pathname: config[DataSelectionType.BAG].path,
+          pathname: config[DataSelectionType.BRK].path,
           search: `${PARAMETERS.VIEW}=volledig&${PARAMETERS.FILTERS}={"${filters.key}":"${filters.value}"}`,
         },
         title: 'In tabel weergeven',


### PR DESCRIPTION
This PR fixes an issue where links to 'vestiging' and 'kadastraal object' table views were pointing to the 'adressen' table view.