### PR TITLE
(Chore) isAuthenticated

### DIFF
--- a/src/shared/services/auth/auth.ts
+++ b/src/shared/services/auth/auth.ts
@@ -306,3 +306,18 @@ export function getAuthHeaders() {
   const accessToken = getAccessToken()
   return accessToken ? { Authorization: `Bearer ${getAccessToken()}` } : {}
 }
+
+export function isAuthenticated() {
+  const accessToken = getAccessToken()
+
+  if (!accessToken) return false
+
+  const decoded = parseAccessToken(accessToken)
+
+  if (!decoded?.expiresAt) return false
+
+  const now = Date.now()
+  const hasExpired = decoded.expiresAt * 1000 < now
+
+  return !hasExpired
+}

--- a/src/shared/services/auth/parseAccessToken.ts
+++ b/src/shared/services/auth/parseAccessToken.ts
@@ -11,7 +11,7 @@ interface DecodedToken {
 function decodeToken(token: string): DecodedToken | null {
   try {
     return JSON.parse(window.atob(token.split('.')[1].replace('-', '+').replace('_', '/')))
-  } catch (e) {
+  } catch {
     return null
   }
 }


### PR DESCRIPTION
This PR adds the `isAuthenticated` function to the `auth` module. This allows us to do the following:
```javascript
import { isAuthenticated, getAccessToken } from '/shared/services/auth/auth'

const fetchData = async (requestURL: string, headers: any, options: any) => {
  const authHeaders = isAuthenticated() ? { Authorization: `Bearer ${getAccessToken()}` } : {}
  const requestHeaders = {
    'Content-Type': 'application/json',
    Accept: 'application/json',
    ...headers,
    ...authHeaders,
  }

  // handle fetch
}
```

It also allows us to shield off specific parts of the application by just checking the return value of `isAuthenticated()`. Another benefit is that, when proxying fetch requests in tests, it will allow us to provide test cases with specific data based on the return value of `isAuthenticated()` since some endpoints return different outputs based on the authentication level of a user.