### PR TITLE
[DI-1154] Adres redirect fix

### DIFF
--- a/src/app/redirects.js
+++ b/src/app/redirects.js
@@ -159,7 +159,7 @@ export const overviewUrls = overviewPaths.map((pathName) => ({
 
 export const webHooks = [
   {
-    from: `/adres/zoek${window.location.search}`,
+    from: `/adres/zoek/${window.location.search}`,
     to: `/data/bag/verblijfsobject/`,
     load: getVerblijfsobjectIdFromAddressQuery,
   },


### PR DESCRIPTION
This PR fixes an issue where a possible URL redirect match would not redirect as expected. The cause is a URL rewrite in the application that rewrites `adres/zoek?postcode=1016KR&huisletter=A&huisnummerToevoeging=H&huisnummer=13` to `adres/zoek/?postcode=1016KR&huisletter=A&huisnummerToevoeging=H&huisnummer=13` (note the slash after `/zoek`). The first URL matched one of the configured webhooks whereas the second did not.