### PR TITLE
Remove related articles from publication detail page

### DIFF
--- a/src/app/pages/PublicationDetailPage/PublicationDetailPage.jsx
+++ b/src/app/pages/PublicationDetailPage/PublicationDetailPage.jsx
@@ -6,18 +6,12 @@ import {
   Heading,
   Paragraph,
   Row,
-  List,
-  ListItem,
-  Link,
 } from '@amsterdam/asc-ui'
 import { useMatomo } from '@datapunt/matomo-tracker-react'
 import React, { useEffect } from 'react'
-import { useParams, Link as RouterLink } from 'react-router-dom'
-import { generatePath } from 'react-router'
-import { routing } from '../../routes'
+import { useParams } from 'react-router-dom'
 import environment from '../../../environment'
 import { cmsConfig } from '../../../shared/config/config'
-import { routingKey } from '../../../shared/config/cms.config'
 import { toPublicationDetail } from '../../../store/redux-first-router/actions'
 import ContentContainer from '../../components/ContentContainer/ContentContainer'
 import DocumentCover from '../../components/DocumentCover/DocumentCover'
@@ -49,7 +43,6 @@ const PublicationDetailPage = () => {
     field_intro: intro,
     field_language: lang,
     slug,
-    related,
   } = results || {}
 
   const documentTitle = title && `Publicatie: ${title}`
@@ -104,24 +97,6 @@ const PublicationDetailPage = () => {
                   <EditorialContent>
                     {intro && <Paragraph strong dangerouslySetInnerHTML={{ __html: intro }} />}
                     {body && <CustomHTMLBlock body={body} />}
-                    {related?.length ? (
-                      <List>
-                        {related.map(({ id: linkId, title: linkTitle, type, to }) => (
-                          <ListItem key={linkId}>
-                            <Link
-                              as={RouterLink}
-                              to={generatePath(routing[routingKey[type]].path, {
-                                slug: to.payload.slug,
-                                id: to.payload.id,
-                              })}
-                              inList
-                            >
-                              {linkTitle}
-                            </Link>
-                          </ListItem>
-                        ))}
-                      </List>
-                    ) : null}
                   </EditorialContent>
                 </Column>
               </Column>

--- a/src/shared/config/cms.config.ts
+++ b/src/shared/config/cms.config.ts
@@ -66,7 +66,7 @@ const cmsConfig = {
   },
   PUBLICATION: {
     endpoint: (id: string) =>
-      `${environment.CMS_ROOT}jsonapi/node/publication/${id}?include=field_cover_image.field_media_image,field_file.field_media_file,field_related.field_teaser_image.field_media_image`,
+      `${environment.CMS_ROOT}jsonapi/node/publication/${id}?include=field_cover_image.field_media_image,field_file.field_media_file`,
     fields: [
       'field_file.field_media_file.uri',
       'field_file_size',
@@ -75,18 +75,6 @@ const cmsConfig = {
       'field_publication_year',
       'field_publication_month',
       'field_publication_day',
-      'field_related.id',
-      'field_related.title',
-      'field_related.field_intro',
-      'field_related.field_byline',
-      'field_related.field_publication_date',
-      'field_related.field_teaser_image.field_media_image.uri',
-      'field_related.field_cover_image.field_media_image.uri',
-      'field_related.field_special_type',
-      'field_related.field_short_title',
-      'field_related.field_teaser',
-      'field_related.field_type',
-      'field_related.type',
       ...SHARED_FIELDS,
     ],
   },


### PR DESCRIPTION
The API sometimes returns exceptions, once these issues are resolved we can restore this functionality.

This reverts commit 81bc2ceebf6fd031f9e6f4a46743eec6f2631cd0.