### PR TITLE
(Chore) Fix fetchProxy searchParams

### DIFF
--- a/src/shared/services/api/api.test.ts
+++ b/src/shared/services/api/api.test.ts
@@ -147,6 +147,22 @@ describe('Api service', () => {
       )
     })
 
+    it('should append query string to request URL with search params', async () => {
+      expect(global.fetch).not.toHaveBeenCalled()
+
+      const searchParams = {
+        foo: 'bar',
+        qux: 'zork',
+      }
+      const url = 'https://www.domain2.com?filter=a&page=1'
+      await fetchProxy(url, { searchParams })
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('filter=a&page=1&foo=bar&qux=zork'),
+        expect.objectContaining({ headers: expect.anything() }),
+      )
+    })
+
     it('should append auth headers to request', async () => {
       expect(global.fetch).not.toHaveBeenCalled()
 

--- a/src/shared/services/api/api.ts
+++ b/src/shared/services/api/api.ts
@@ -80,7 +80,7 @@ export const createUrlWithToken = (url: string, token: string) => {
 }
 
 export const fetchProxy = <T = any>(url: string, init: FetchOptions = {}): Promise<T> => {
-  const { headers, searchParams, ...otherOptions } = init
+  const { headers, searchParams = {}, ...otherOptions } = init
   const requestHeaders = new Headers(headers)
   const authHeaders = Object.entries(getAuthHeaders())
 
@@ -95,8 +95,13 @@ export const fetchProxy = <T = any>(url: string, init: FetchOptions = {}): Promi
 
   const fullUrl = new URL(url)
   const params = new URLSearchParams(searchParams)
+  const paramsInUrl = fullUrl.searchParams
 
-  fullUrl.search = params.toString()
+  params.forEach((value, key) => {
+    paramsInUrl.set(key, value)
+  })
+
+  fullUrl.search = paramsInUrl.toString()
 
   return fetch(fullUrl.toString(), options)
     .then((response) => handleErrors(response))


### PR DESCRIPTION
This PR contains a fix for the `fetchProxy` API function. Calling the function with the `url` parameter already containing a search string, would remove that string. With the fix, any search params will get appended to the exiting search string.