### PR TITLE
(Chore) Nginx allow localhost:8080

### DIFF
--- a/nginx.csp.dev.conf
+++ b/nginx.csp.dev.conf
@@ -1,6 +1,6 @@
 add_header Content-Security-Policy
   "default-src 'self';
-  connect-src 'self' https://*.data.amsterdam.nl localhost;
+  connect-src 'self' https://*.data.amsterdam.nl localhost localhost:8080;
   font-src 'self' https://static.amsterdam.nl fast.fonts.net;
   frame-src 'self' blob: https://*.amsterdam.nl https://ois-amsterdam.gitlab.io;
   media-src 'self' https://*.data.amsterdam.nl;


### PR DESCRIPTION
Updates the local nginx config so that connections to and from the locally running `cms_search` container are accepted