### PR TITLE
[DI2-119] Publication date fix

### DIFF
--- a/src/app/components/EditorialResults/EditorialResults.tsx
+++ b/src/app/components/EditorialResults/EditorialResults.tsx
@@ -2,7 +2,7 @@ import { CardContainer } from '@amsterdam/asc-ui'
 import { GraphQLFormattedError } from 'graphql'
 import { FunctionComponent, memo } from 'react'
 import styled from 'styled-components'
-import { EDITORIAL_DETAIL_ACTIONS } from '../../../normalizations/cms/useNormalizedCMSResults'
+import { EDITORIAL_DETAIL_ACTIONS } from '../../../normalizations/cms/normalizeCMSResults'
 import { CmsType } from '../../../shared/config/cms.config'
 import {
   toArticleSearch,

--- a/src/app/pages/ArticleDetailPage/ArticleDetailPage.jsx
+++ b/src/app/pages/ArticleDetailPage/ArticleDetailPage.jsx
@@ -26,9 +26,9 @@ import { useParams } from 'react-router-dom'
 import styled, { css } from 'styled-components'
 import environment from '../../../environment'
 import normalizeDownloadsObject from '../../../normalizations/cms/normalizeDownloadFiles'
-import useNormalizedCMSResults, {
+import normalizeCMSResults, {
   EDITORIAL_FIELD_TYPE_VALUES,
-} from '../../../normalizations/cms/useNormalizedCMSResults'
+} from '../../../normalizations/cms/normalizeCMSResults'
 import cmsConfig from '../../../shared/config/cms.config'
 import ContentContainer from '../../components/ContentContainer/ContentContainer'
 import EditorialPage from '../../components/EditorialPage/EditorialPage'
@@ -251,7 +251,7 @@ const ArticleDetailPage = () => {
                             <Divider />
                             <StyledEditorialResults
                               headingLevel="h2"
-                              results={useNormalizedCMSResults(related)}
+                              results={normalizeCMSResults(related)}
                               errors={[]}
                               title="Verder lezen"
                             />

--- a/src/app/utils/useFromCMS.test.ts
+++ b/src/app/utils/useFromCMS.test.ts
@@ -1,18 +1,18 @@
 import { renderHook } from '@testing-library/react-hooks'
 import { mocked } from 'ts-jest/utils'
-import useNormalizedCMSResults from '../../normalizations/cms/useNormalizedCMSResults'
+import normalizeCMSResults from '../../normalizations/cms/normalizeCMSResults'
 import { fetchWithToken } from '../../shared/services/api/api'
 import cmsJsonApiNormalizer from '../../shared/services/cms/cms-json-api-normalizer'
 import useFromCMS from './useFromCMS'
 
 jest.mock('../../shared/services/api/api')
 jest.mock('../../shared/services/cms/cms-json-api-normalizer')
-jest.mock('../../normalizations/cms/useNormalizedCMSResults')
+jest.mock('../../normalizations/cms/normalizeCMSResults')
 jest.useFakeTimers()
 
 const mockedFetchWithToken = mocked(fetchWithToken, true)
 const mockedCmsJsonApiNormalizer = mocked(cmsJsonApiNormalizer, true)
-const mockedUseNormalizedCMSResults = mocked(useNormalizedCMSResults, true)
+const mockedNormalizeCMSResults = mocked(normalizeCMSResults, true)
 
 describe('useFromCMS', () => {
   const id = '3'
@@ -24,7 +24,7 @@ describe('useFromCMS', () => {
   beforeEach(() => {
     mockedFetchWithToken.mockReturnValueOnce(Promise.resolve(mockData))
     mockedCmsJsonApiNormalizer.mockReturnValueOnce(Promise.resolve(mockData))
-    mockedUseNormalizedCMSResults.mockReturnValueOnce(mockData)
+    mockedNormalizeCMSResults.mockReturnValueOnce(mockData)
   })
 
   afterEach(() => {
@@ -60,7 +60,7 @@ describe('useFromCMS', () => {
     await waitForNextUpdate()
 
     // handle the normalization
-    expect(mockedUseNormalizedCMSResults).toHaveBeenCalled()
+    expect(mockedNormalizeCMSResults).toHaveBeenCalled()
 
     expect(result.current.loading).toBe(false)
     expect(result.current.results).toEqual(mockData)

--- a/src/app/utils/useFromCMS.ts
+++ b/src/app/utils/useFromCMS.ts
@@ -2,7 +2,7 @@
 import { LocationDescriptorObject } from 'history'
 import { useState } from 'react'
 import { To } from 'redux-first-router-link'
-import useNormalizedCMSResults from '../../normalizations/cms/useNormalizedCMSResults'
+import normalizeCMSResults from '../../normalizations/cms/normalizeCMSResults'
 import { CmsType, SpecialType } from '../../shared/config/cms.config'
 import { fetchWithToken } from '../../shared/services/api/api'
 import cmsJsonApiNormalizer from '../../shared/services/cms/cms-json-api-normalizer'
@@ -81,12 +81,12 @@ function useFromCMS<T = CMSResultItem[]>(
           // @ts-ignore
           field_blocks: result.field_blocks.map(({ field_content, ...otherFields }) => ({
             ...otherFields,
-            field_content: useNormalizedCMSResults(field_content),
+            field_content: normalizeCMSResults(field_content),
           })),
-          field_items: useNormalizedCMSResults(result.field_items),
+          field_items: normalizeCMSResults(result.field_items),
         }
       } else {
-        result = useNormalizedCMSResults(result)
+        result = normalizeCMSResults(result)
       }
       setResults(result)
     } catch (e) {

--- a/src/normalizations/cms/normalizeCMSResults.js
+++ b/src/normalizations/cms/normalizeCMSResults.js
@@ -160,7 +160,7 @@ export const normalizeObject = (data) => {
   }
 }
 
-const useNormalizedCMSResults = (data) => {
+const normalizeCMSResults = (data) => {
   // The data can be in the form of an array when used on the homepage or an overview page
   if (data.results || (data && data.length)) {
     const dataArray = data.results || data
@@ -178,4 +178,4 @@ const useNormalizedCMSResults = (data) => {
   return normalizeObject(data)
 }
 
-export default useNormalizedCMSResults
+export default normalizeCMSResults

--- a/src/normalizations/cms/normalizeCMSResults.test.js
+++ b/src/normalizations/cms/normalizeCMSResults.test.js
@@ -1,11 +1,11 @@
 import { toArticleDetail } from '../../app/links'
 import { toSpecialDetail } from '../../store/redux-first-router/actions'
 import { CmsType } from '../../shared/config/cms.config'
-import useNormalizedCMSResults, {
+import normalizeCMSResults, {
   getLinkProps,
   getLocaleFormattedDate,
   normalizeObject,
-} from './useNormalizedCMSResults'
+} from './normalizeCMSResults'
 
 jest.mock('../../app/links')
 jest.mock('../../store/redux-first-router/actions')
@@ -13,7 +13,7 @@ jest.mock('../../store/redux-first-router/actions')
 toArticleDetail.mockImplementation(() => 'to-article')
 toSpecialDetail.mockImplementation(() => 'to-special')
 
-describe('useNormalizedCMSResults', () => {
+describe('normalizeCMSResults', () => {
   describe('getLocaleFormattedDate', () => {
     /* eslint-disable camelcase */
     it('returns an object with empty values', () => {
@@ -272,17 +272,17 @@ describe('useNormalizedCMSResults', () => {
     })
 
     it('normalizes the data when it is an array', () => {
-      expect(useNormalizedCMSResults([input])).toMatchObject([output])
+      expect(normalizeCMSResults([input])).toMatchObject([output])
 
-      expect(useNormalizedCMSResults({ results: [input] })).toMatchObject([output])
+      expect(normalizeCMSResults({ results: [input] })).toMatchObject([output])
     })
 
     it('normalizes the data when it is NOT an array', () => {
-      expect(useNormalizedCMSResults(input)).toMatchObject(output)
+      expect(normalizeCMSResults(input)).toMatchObject(output)
     })
 
     it('normalizes the data when it is an array with links to other data', () => {
-      expect(useNormalizedCMSResults({ results: [{ ...input }], _links: [] })).toMatchObject({
+      expect(normalizeCMSResults({ results: [{ ...input }], _links: [] })).toMatchObject({
         data: [output],
         links: [],
       })

--- a/src/normalizations/cms/useNormalizedCMSResults.js
+++ b/src/normalizations/cms/useNormalizedCMSResults.js
@@ -48,11 +48,13 @@ export const getLocaleFormattedDate = ({
 
   const day = parseInt(field_publication_day, 10)
   const monthIndex = parseInt(field_publication_month, 10)
+  const monthIsValidNumber = Number.isNaN(monthIndex) === false
+  const dayIsValidNumber = Number.isNaN(day) === false
 
   const dateParts = [
     year,
-    !Number.isNaN(monthIndex) && Math.max(0, monthIndex - 1),
-    !Number.isNaN(day) && day,
+    monthIsValidNumber && Math.max(0, monthIndex - 1),
+    dayIsValidNumber && day,
   ].filter(Number.isFinite)
 
   const localeDate = new Date(Date.UTC(...dateParts))

--- a/src/normalizations/cms/useNormalizedCMSResults.js
+++ b/src/normalizations/cms/useNormalizedCMSResults.js
@@ -42,7 +42,7 @@ export const getLocaleFormattedDate = ({
   if (field_publication_date) {
     return {
       localeDate: field_publication_date,
-      localeDateFormatted: formatDate(new Date(field_publication_date.replace(' ', 'T'))),
+      localeDateFormatted: formatDate(new Date(field_publication_date)),
     }
   }
 

--- a/src/normalizations/cms/useNormalizedCMSResults.js
+++ b/src/normalizations/cms/useNormalizedCMSResults.js
@@ -51,9 +51,9 @@ export const getLocaleFormattedDate = ({
 
   const dateParts = [
     year,
-    !Number.isNaN(monthIndex) && monthIndex - 1,
+    !Number.isNaN(monthIndex) && Math.max(0, monthIndex - 1),
     !Number.isNaN(day) && day,
-  ].filter(Boolean)
+  ].filter(Number.isFinite)
 
   const localeDate = new Date(Date.UTC(...dateParts))
 

--- a/src/normalizations/cms/useNormalizedCMSResults.test.js
+++ b/src/normalizations/cms/useNormalizedCMSResults.test.js
@@ -92,6 +92,26 @@ describe('useNormalizedCMSResults', () => {
         `${field_publication_day}-${field_publication_month}-${field_publication_year}`,
       )
     })
+
+    it('returns an object with dates from field_publication_year, field_publication_month and field_publication_day 1', () => {
+      const field_publication_year = 2020
+      const field_publication_month = 1
+      const field_publication_day = 1
+      const { localeDate, localeDateFormatted } = getLocaleFormattedDate({
+        field_publication_year,
+        field_publication_month,
+        field_publication_day,
+      })
+
+      expect(localeDate).toEqual(
+        new Date(
+          Date.UTC(field_publication_year, field_publication_month - 1, field_publication_day),
+        ),
+      )
+      expect(localeDateFormatted).toEqual(
+        `${field_publication_day}-${field_publication_month}-${field_publication_year}`,
+      )
+    })
     /* eslint-enable camelcase */
   })
 

--- a/src/normalizations/cms/useNormalizedCMSResults.test.js
+++ b/src/normalizations/cms/useNormalizedCMSResults.test.js
@@ -1,148 +1,237 @@
 import { toArticleDetail } from '../../app/links'
-import formatDate from '../../app/utils/formatDate'
-import toSlug from '../../app/utils/toSlug'
 import { CmsType } from '../../shared/config/cms.config'
-import useNormalizedCMSResults from './useNormalizedCMSResults'
-
-jest.mock('../../app/utils/toSlug')
-jest.mock('../../app/utils/formatDate')
+import useNormalizedCMSResults, {
+  getLocaleFormattedDate,
+  normalizeObject,
+} from './useNormalizedCMSResults'
 
 describe('useNormalizedCMSResults', () => {
-  const slug = 'this-is-a-slug'
-  const formattedDate = 'pretty date'
+  describe('getLocaleFormattedDate', () => {
+    /* eslint-disable camelcase */
+    it('returns an object with empty values', () => {
+      const { localeDate, localeDateFormatted } = getLocaleFormattedDate()
 
-  beforeEach(() => {
-    toSlug.mockImplementation(() => slug)
-    formatDate.mockImplementation(() => formattedDate)
-  })
-  const input = {
-    uuid: 'id',
-    title: 'title',
-    type: 'foo',
-    body: {
-      value: 'body',
-    },
-    teaser_url: 'teaser_url',
-    media_image_url: 'media_image_url',
-
-    short_title: 'short_title',
-    field_teaser: 'field_teaser',
-    intro: 'intro',
-    field_special_type: 'field_special_type',
-    field_publication_date: '2012-12-12',
-  }
-
-  const output = {
-    key: input.uuid,
-    id: input.uuid,
-    title: input.title,
-    type: input.type,
-    body: input.body.value,
-    teaserImage: input.teaser_url,
-    coverImage: input.media_image_url,
-    imageIsVertical: false,
-    shortTitle: input.short_title,
-    teaser: input.field_teaser,
-    intro: input.intro,
-    specialType: input.field_special_type,
-    fileUrl: undefined,
-    localeDate: input.field_publication_date,
-    localeDateFormatted: formattedDate,
-    slug,
-    to: {},
-    related: [],
-  }
-
-  it('should normalize the data to use in the application', () => {
-    expect(useNormalizedCMSResults(input)).toMatchObject(output)
-  })
-
-  it('should have a vertical image and file url for publications', () => {
-    expect(
-      useNormalizedCMSResults({
-        ...input,
-        type: CmsType.Publication,
-        field_file: { field_media_file: { uri: { url: 'url' } } },
-      }),
-    ).toMatchObject({
-      imageIsVertical: true,
-      fileUrl: 'url',
+      expect(localeDate).toEqual('')
+      expect(localeDateFormatted).toEqual('')
     })
-  })
 
-  it('should set the "to" prop', () => {
-    expect(
-      useNormalizedCMSResults({
-        ...input,
-        type: CmsType.Article,
-      }),
-    ).toMatchObject({
-      to: toArticleDetail(input.uuid, slug),
+    it('returns an object with empty values from an empty options object', () => {
+      const { localeDate, localeDateFormatted } = getLocaleFormattedDate({})
+
+      expect(localeDate).toEqual('')
+      expect(localeDateFormatted).toEqual('')
     })
+
+    it('returns an object with empty values when options do not contain a possible valid date', () => {
+      const { localeDate, localeDateFormatted } = getLocaleFormattedDate({
+        field_publication_year: 'foobar',
+      })
+
+      expect(localeDate).toEqual('')
+      expect(localeDateFormatted).toEqual('')
+    })
+
+    it('returns an object with dates from field_publication_date', () => {
+      const field_publication_date = '2020-12-02T16:00:00+01:00'
+      const { localeDate, localeDateFormatted } = getLocaleFormattedDate({
+        field_publication_date,
+      })
+
+      expect(localeDate).toEqual(field_publication_date)
+      expect(localeDateFormatted).toEqual('2 december 2020')
+    })
+
+    it('returns an object with dates from field_publication_year', () => {
+      const field_publication_year = '2020'
+      const { localeDate, localeDateFormatted } = getLocaleFormattedDate({
+        field_publication_year,
+      })
+
+      expect(localeDate).toEqual(new Date(Date.UTC(field_publication_year)))
+      expect(localeDateFormatted).toEqual(`1-1-${field_publication_year}`)
+    })
+
+    it('returns an object with dates from field_publication_year and field_publication_month', () => {
+      const field_publication_year = '2020'
+      const field_publication_month = 12
+      const { localeDate, localeDateFormatted } = getLocaleFormattedDate({
+        field_publication_year,
+        field_publication_month,
+      })
+
+      expect(localeDate).toEqual(
+        new Date(Date.UTC(field_publication_year, field_publication_month - 1)),
+      )
+      expect(localeDateFormatted).toEqual(`1-${field_publication_month}-${field_publication_year}`)
+    })
+
+    it('returns an object with dates from field_publication_year, field_publication_month and field_publication_day', () => {
+      const field_publication_year = 2020
+      const field_publication_month = 10
+      const field_publication_day = 31
+      const { localeDate, localeDateFormatted } = getLocaleFormattedDate({
+        field_publication_year,
+        field_publication_month,
+        field_publication_day,
+      })
+
+      expect(localeDate).toEqual(
+        new Date(
+          Date.UTC(field_publication_year, field_publication_month - 1, field_publication_day),
+        ),
+      )
+      expect(localeDateFormatted).toEqual(
+        `${field_publication_day}-${field_publication_month}-${field_publication_year}`,
+      )
+    })
+    /* eslint-enable camelcase */
   })
 
-  it('should set the link props', () => {
-    const href = 'href'
-    expect(
-      useNormalizedCMSResults({
-        ...input,
-        field_link: {
-          uri: href,
-        },
-      }),
-    ).toMatchObject({
-      linkProps: {
-        forwardedAs: 'a',
-        href,
+  describe('normalizeObject', () => {
+    const input = {
+      uuid: 'id',
+      title: 'title',
+      type: 'foo',
+      body: {
+        value: 'body',
       },
-    })
-  })
+      teaser_url: 'teaser_url',
+      media_image_url: 'media_image_url',
 
-  it('should set the "related" prop', () => {
-    const related = {
-      id: 'id',
-      teaserImage: 'teaserImage',
-      shortTitle: 'shortTitle',
+      short_title: 'short_title',
+      field_teaser: 'field_teaser',
+      intro: 'intro',
+      field_special_type: 'field_special_type',
+      field_publication_date: '',
     }
 
-    expect(
-      useNormalizedCMSResults({
-        ...input,
-        field_related: [{ ...input, ...related }],
-      }),
-    ).toMatchObject({
-      related: [
-        {
-          ...output,
-          id: related.id,
-          intro: undefined,
-          key: related.id,
-          shortTitle: related.shortTitle,
-          teaserImage: related.teaserImage,
+    const output = {
+      key: input.uuid,
+      id: input.uuid,
+      title: input.title,
+      type: input.type,
+      body: input.body.value,
+      teaserImage: input.teaser_url,
+      coverImage: input.media_image_url,
+      imageIsVertical: false,
+      shortTitle: input.short_title,
+      teaser: input.field_teaser,
+      intro: input.intro,
+      specialType: input.field_special_type,
+      fileUrl: undefined,
+      localeDate: '',
+      localeDateFormatted: '',
+      slug: input.title,
+      to: {},
+      related: [],
+    }
+
+    it('normalizes the data to use in the application', () => {
+      expect(normalizeObject(input)).toMatchObject(output)
+    })
+
+    it('has a vertical image and file url for publications', () => {
+      expect(
+        normalizeObject({
+          ...input,
+          type: CmsType.Publication,
+          field_file: { field_media_file: { uri: { url: 'url' } } },
+        }),
+      ).toMatchObject({
+        imageIsVertical: true,
+        fileUrl: 'url',
+      })
+    })
+
+    it('sets the "to" prop', () => {
+      expect(
+        normalizeObject({
+          ...input,
+          type: CmsType.Article,
+        }),
+      ).toMatchObject({
+        to: toArticleDetail(input.uuid, output.slug),
+      })
+    })
+
+    it('sets the link props', () => {
+      const href = 'href'
+      expect(
+        normalizeObject({
+          ...input,
+          field_link: {
+            uri: href,
+          },
+        }),
+      ).toMatchObject({
+        linkProps: {
+          forwardedAs: 'a',
+          href,
         },
-      ],
+      })
     })
-  })
 
-  it('should normalize the data when it`s an array', () => {
-    expect(useNormalizedCMSResults([input])).toMatchObject([output])
+    it('sets the "related" prop', () => {
+      const related = {
+        id: 'id',
+        teaserImage: 'teaserImage',
+        shortTitle: 'shortTitle',
+      }
 
-    expect(useNormalizedCMSResults({ results: [input] })).toMatchObject([output])
-  })
-
-  it('should normalize the data when it`s an array with links to other data', () => {
-    expect(useNormalizedCMSResults({ results: [{ ...input }], _links: [] })).toMatchObject({
-      data: [output],
-      links: [],
+      expect(
+        normalizeObject({
+          ...input,
+          field_related: [{ ...input, ...related }],
+        }),
+      ).toMatchObject({
+        related: [
+          {
+            ...output,
+            id: related.id,
+            intro: undefined,
+            key: related.id,
+            shortTitle: related.shortTitle,
+            teaserImage: related.teaserImage,
+          },
+        ],
+      })
     })
-  })
 
-  it("should set the date if field_publication_date isn't set", () => {
-    const newInput = { ...input, field_publication_year: '2012', field_publication_month: '1' }
-    delete newInput.field_publication_date
-    expect(useNormalizedCMSResults({ results: [newInput], _links: [] })).toMatchObject({
-      data: [{ ...output, localeDate: new Date(Date.UTC(2012, 0, 1, 0, 0, 0)) }],
-      links: [],
+    it('sets the links prop', () => {
+      const field_links = [
+        { uri: 'http://example.com?foo=bar&amp;baz=qux', title: 'Test', options: [] },
+        { uri: 'internal:/test/', title: 'Test 2', options: [] },
+        { uri: 'entity:node/8', title: 'Foo', options: [] },
+      ]
+      expect(
+        normalizeObject({
+          ...input,
+          field_links,
+        }),
+      ).toMatchObject({
+        links: [
+          { uri: 'http://example.com?foo=bar&baz=qux', title: 'Test', options: [] },
+          { uri: 'internal:/test/', title: 'Test 2', options: [] },
+          { uri: 'entity:node/8', title: 'Foo', options: [] },
+        ],
+      })
+    })
+
+    it('normalizes the data when it is an array', () => {
+      expect(useNormalizedCMSResults([input])).toMatchObject([output])
+
+      expect(useNormalizedCMSResults({ results: [input] })).toMatchObject([output])
+    })
+
+    it('normalizes the data when it is NOT an array', () => {
+      expect(useNormalizedCMSResults(input)).toMatchObject(output)
+    })
+
+    it('normalizes the data when it is an array with links to other data', () => {
+      expect(useNormalizedCMSResults({ results: [{ ...input }], _links: [] })).toMatchObject({
+        data: [output],
+        links: [],
+      })
     })
   })
 })

--- a/src/shared/services/cms/cms-json-api-normalizer.js
+++ b/src/shared/services/cms/cms-json-api-normalizer.js
@@ -4,7 +4,7 @@ import normalize from 'json-api-normalize'
 export const getType = (type) => type && type.replace('node--', '')
 
 function getNormalizedItem(item, extraData = {}) {
-  // Make sure the correct fields have data here to be used by useNormalizedCMSResults()
+  // Make sure the correct fields have data here to be used by normalizeCMSResults()
   return {
     ...extraData,
     ...item,


### PR DESCRIPTION
This PR fixes an issue where an article's publication date wouldn't be shown correctly. The cause of this was that the code wasn't using the value of `field_publication_day` which rendered the date always with day 1.

In order to fix the issue, the tests for `useNormalizedCMSResults.js` have been rewritten and the file has been refactored by moving functionality out of the main function so it can be tested separately. The functionality slightly changed in that passing in a value for `field_publication_year` and none for `field_publication_month` will show the year (instead of throwing an error). Passing in a value for both `field_publication_year` and `field_publication_month` will always show 1-{month}-{year}.