### PR TITLE
[DI2-265] ADR Keycloak implementation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,12 @@ services:
       - IIIF_ROOT=https://images.data.amsterdam.nl/
       - GRAPHQL_ENDPOINT=https://api.data.amsterdam.nl/cms_search/graphql/
       - ROOT=http://localhost:3000/
+
+  keycloak:
+    image: jboss/keycloak
+    command: '-b 0.0.0.0 -Djboss.http.port=8080'
+    ports:
+      - '8080:8080'
+    environment:
+      - KEYCLOAK_USER=admin
+      - KEYCLOAK_PASSWORD=admin

--- a/docs/adr/003-keycloak-implementation.md
+++ b/docs/adr/003-keycloak-implementation.md
@@ -10,27 +10,14 @@ Proposed
 
 The `atlas` application offers visitors a way to authenticate their session so that specific, privacy sensitive, data can be viewed that would otherwise be inaccessible. The authentication mechanism is provided by a service (Amsterdam Authz) that was developed in-house several years ago. It queries an internal database (IdP) as well as the active directory of registered users at the municipality of Amsterdam. The latter uses [Grip](https://www.grip-on-it.com/) which isn't officially supported anymore (or wasn't ever) and will be discontinued in the near future. As a replacement authorization service, Keycloak has been chosen. It has, at the time of writing, been implemented by [blackspots-frontend](https://github.com/Amsterdam/blackspots-frontend), [zaken-frontend](https://github.com/Amsterdam/zaken-frontend), [fixxx-looplijsten-frontend](https://github.com/Amsterdam/fixxx-looplijsten-frontend) and [signals-frontend](https://github.com/Amsterdam/signals-frontend).
 
-## Decision
+The Keycloak authorization service has [a JS package](https://github.com/keycloak/keycloak) and [a React package](https://github.com/react-keycloak/react-keycloak) that can be used to replace the Amsterdam Authz service with. Note that none of the mentioned Amsterdam projects use the React package.
 
-The Keycloak authorization service has [a JS package](https://github.com/keycloak/keycloak) and [a React package](https://github.com/react-keycloak/react-keycloak) that can be used to replace the Amsterdam Authz service with.
-
-To test it, a Keycloak server can be set up locally with Docker, by adding the following to the `docker-compose` file:
-
-```
-keycloak:
-  image: jboss/keycloak
-  command: '-b 0.0.0.0 -Djboss.http.port=8080 -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=dir -Dkeycloak.migration.dir=/tmp/export -Dkeycloak.migration.strategy=OVERWRITE_EXISTING'
-  ports:
-    - '8080:8080'
-  environment:
-    - KEYCLOAK_USER=admin
-    - KEYCLOAK_PASSWORD=admin
-  volumes:
-    - './internals/keycloak/export:/tmp/export'
-```
+To test it, a Keycloak server can be set up locally with Docker. See the [`docker-compose`](../../docker-compose.yml).
 
 [The Keycloak documentation](https://www.keycloak.org/docs/latest/authorization_services/index.html#_authorization_quickstarts) describes the process of creating a realm and a user for that realm. Without it, the service cannot be tested.
 
-By default, the authenticated sessions are valid for a maximum of five minutes. The Keycloak service instance should be configured to refresh the token before it expires to prevent users from logging out during their active session.
+By default, access tokens are valid for a maximum of five minutes. The Keycloak service instance should be configured to refresh the token before it expires to prevent users from logging out during their active session.
 
-## Consequences
+## Decision
+
+The [react-keycloak package](https://github.com/react-keycloak/react-keycloak)] can be used to replace the current implementation. The available `useKeyclock` hook can be used to verify if a user is authenticated and the `init` function can be passed props to refresh the access token at a set interval so that sessions do not expire.

--- a/docs/adr/003-keycloak-implementation.md
+++ b/docs/adr/003-keycloak-implementation.md
@@ -20,4 +20,8 @@ By default, access tokens are valid for a maximum of five minutes. The Keycloak 
 
 ## Decision
 
-The [react-keycloak package](https://github.com/react-keycloak/react-keycloak)] can be used to replace the current implementation. The available `useKeyclock` hook can be used to verify if a user is authenticated and the `init` function can be passed props to refresh the access token at a set interval so that sessions do not expire.
+The [react-keycloak package](https://github.com/react-keycloak/react-keycloak) can be used to replace the current implementation. The available `useKeyclock` hook can be used to verify if a user is authenticated and the `init` function can be passed props to refresh the access token at a set interval so that sessions do not expire.
+
+## Consequences
+
+All of the entries in the IdP need to be transferred to the Keycloak service before Keycloak can fully replace the existing Authz service.

--- a/docs/adr/003-keycloak-implementation.md
+++ b/docs/adr/003-keycloak-implementation.md
@@ -1,0 +1,36 @@
+# Keycloak implementation
+
+Date: 10-02-2021
+
+## Status
+
+Proposed
+
+## Context
+
+The `atlas` application offers visitors a way to authenticate their session so that specific, privacy sensitive, data can be viewed that would otherwise be inaccessible. The authentication mechanism is provided by a service (Amsterdam Authz) that was developed in-house several years ago. It queries an internal database (IdP) as well as the active directory of registered users at the municipality of Amsterdam. The latter uses [Grip](https://www.grip-on-it.com/) which isn't officially supported anymore (or wasn't ever) and will be discontinued in the near future. As a replacement authorization service, Keycloak has been chosen. It has, at the time of writing, been implemented by [blackspots-frontend](https://github.com/Amsterdam/blackspots-frontend), [zaken-frontend](https://github.com/Amsterdam/zaken-frontend), [fixxx-looplijsten-frontend](https://github.com/Amsterdam/fixxx-looplijsten-frontend) and [signals-frontend](https://github.com/Amsterdam/signals-frontend).
+
+## Decision
+
+The Keycloak authorization service has [a JS package](https://github.com/keycloak/keycloak) and [a React package](https://github.com/react-keycloak/react-keycloak) that can be used to replace the Amsterdam Authz service with.
+
+To test it, a Keycloak server can be set up locally with Docker, by adding the following to the `docker-compose` file:
+
+```
+keycloak:
+  image: jboss/keycloak
+  command: '-b 0.0.0.0 -Djboss.http.port=8080 -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=dir -Dkeycloak.migration.dir=/tmp/export -Dkeycloak.migration.strategy=OVERWRITE_EXISTING'
+  ports:
+    - '8080:8080'
+  environment:
+    - KEYCLOAK_USER=admin
+    - KEYCLOAK_PASSWORD=admin
+  volumes:
+    - './internals/keycloak/export:/tmp/export'
+```
+
+[The Keycloak documentation](https://www.keycloak.org/docs/latest/authorization_services/index.html#_authorization_quickstarts) describes the process of creating a realm and a user for that realm. Without it, the service cannot be tested.
+
+By default, the authenticated sessions are valid for a maximum of five minutes. The Keycloak service instance should be configured to refresh the token before it expires to prevent users from logging out during their active session.
+
+## Consequences

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,6 +3,7 @@
 0. [Decisions prior to architectural decision documentation](000-historic-decisions.md)
 1. [Create a GraphQL "normalization" server](001-graphql-server.md)
 2. [Proxy for requests in tests](002-proxy-for-requests-in-tests.md)
+3. [Keycloak implementation](003-keycloak-implementation.md)
 
 ## Resources
 

--- a/nginx.csp.dev.conf
+++ b/nginx.csp.dev.conf
@@ -2,7 +2,7 @@ add_header Content-Security-Policy
   "default-src 'self';
   connect-src 'self' https://*.data.amsterdam.nl localhost localhost:8080;
   font-src 'self' https://static.amsterdam.nl fast.fonts.net;
-  frame-src 'self' blob: https://*.amsterdam.nl https://ois-amsterdam.gitlab.io;
+  frame-src 'self' data: localhost:8080 blob: https://*.amsterdam.nl https://ois-amsterdam.gitlab.io;
   media-src 'self' https://*.data.amsterdam.nl;
   img-src 'self' blob: https://data.amsterdam.nl https://*.data.amsterdam.nl data: https://*.amsterdam.nl https://geodata.nationaalgeoregister.nl localhost;
   script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.data.amsterdam.nl https://static.amsterdam.nl;


### PR DESCRIPTION
This PR adds an ADR on the replacement of the current authentication service with Keycloak.
To provide a testing ground, the `docker-compose` file has been altered as well as the localhost Nginx config.