### PR TITLE
[DI2-294] Missing uuid fix

### DIFF
--- a/src/normalizations/cms/normalizeCMSResults.js
+++ b/src/normalizations/cms/normalizeCMSResults.js
@@ -65,14 +65,19 @@ export const getLocaleFormattedDate = ({
   }
 }
 
-export const getLinkProps = ({ type, uuid, field_link, field_special_type, title }, slug) => {
+export const getLinkProps = ({ type, uuid, id, field_link, field_special_type, title }, slug) => {
   let to = {}
 
+  // not every node has a uuid prop
+  const nodeId = uuid || id
+
   if (EDITORIAL_DETAIL_ACTIONS[type]) {
+    const nodeAnchorPropsFn = EDITORIAL_DETAIL_ACTIONS[type]
+
     if (type === CmsType.Special) {
-      to = EDITORIAL_DETAIL_ACTIONS[type](uuid, field_special_type, slug)
+      to = nodeAnchorPropsFn(nodeId, field_special_type, slug)
     } else {
-      to = EDITORIAL_DETAIL_ACTIONS[type](uuid, slug)
+      to = nodeAnchorPropsFn(nodeId, slug)
     }
   }
 
@@ -90,6 +95,7 @@ export const getLinkProps = ({ type, uuid, field_link, field_special_type, title
 
 export const normalizeObject = (data) => {
   const {
+    id,
     uuid,
     title,
     type,
@@ -137,7 +143,7 @@ export const normalizeObject = (data) => {
 
   return {
     key: uuid,
-    id: uuid,
+    id: id || uuid,
     title,
     type,
     body: body && body.value,

--- a/src/normalizations/cms/normalizeCMSResults.js
+++ b/src/normalizations/cms/normalizeCMSResults.js
@@ -65,19 +65,16 @@ export const getLocaleFormattedDate = ({
   }
 }
 
-export const getLinkProps = ({ type, uuid, id, field_link, field_special_type, title }, slug) => {
+export const getLinkProps = ({ type, id, field_link, field_special_type, title }, slug) => {
   let to = {}
-
-  // not every node has a uuid prop
-  const nodeId = uuid || id
 
   if (EDITORIAL_DETAIL_ACTIONS[type]) {
     const nodeAnchorPropsFn = EDITORIAL_DETAIL_ACTIONS[type]
 
     if (type === CmsType.Special) {
-      to = nodeAnchorPropsFn(nodeId, field_special_type, slug)
+      to = nodeAnchorPropsFn(id, field_special_type, slug)
     } else {
-      to = nodeAnchorPropsFn(nodeId, slug)
+      to = nodeAnchorPropsFn(id, slug)
     }
   }
 
@@ -96,7 +93,6 @@ export const getLinkProps = ({ type, uuid, id, field_link, field_special_type, t
 export const normalizeObject = (data) => {
   const {
     id,
-    uuid,
     title,
     type,
     body,
@@ -142,8 +138,8 @@ export const normalizeObject = (data) => {
   }
 
   return {
-    key: uuid,
-    id: id || uuid,
+    key: id,
+    id,
     title,
     type,
     body: body && body.value,

--- a/src/normalizations/cms/normalizeCMSResults.test.js
+++ b/src/normalizations/cms/normalizeCMSResults.test.js
@@ -78,12 +78,11 @@ describe('normalizeCMSResults', () => {
     })
 
     it('returns an object with dates from field_publication_year, field_publication_month and field_publication_day', () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
+      /* eslint-disable @typescript-eslint/naming-convention */
       const field_publication_year = 2020
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const field_publication_month = 10
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const field_publication_day = 31
+      /* eslint-enable @typescript-eslint/naming-convention */
       const { localeDate, localeDateFormatted } = getLocaleFormattedDate({
         field_publication_year,
         field_publication_month,
@@ -163,10 +162,6 @@ describe('normalizeCMSResults', () => {
   }
 
   describe('getLinkProps', () => {
-    // beforeEach(() => {
-    //   toArticleDetailSpy.mockReset()
-    // })
-
     it('sets the "to" prop', () => {
       expect(
         getLinkProps(

--- a/src/normalizations/cms/normalizeCMSResults.test.js
+++ b/src/normalizations/cms/normalizeCMSResults.test.js
@@ -124,7 +124,7 @@ describe('normalizeCMSResults', () => {
   })
 
   const input = {
-    uuid: 'id',
+    id: 'foobarbaz',
     title: 'title',
     type: 'foo',
     body: {
@@ -141,8 +141,8 @@ describe('normalizeCMSResults', () => {
   }
 
   const output = {
-    key: input.uuid,
-    id: input.uuid,
+    key: input.id,
+    id: input.id,
     title: input.title,
     type: input.type,
     body: input.body.value,
@@ -172,20 +172,7 @@ describe('normalizeCMSResults', () => {
           input.title,
         ),
       ).toMatchObject({
-        to: `${input.uuid}/${input.title}`,
-      })
-    })
-
-    it('falls back to the id prop when the uuid prop is missing', () => {
-      const inputWithoutUuid = {
-        ...input,
-        type: CmsType.Article,
-      }
-      inputWithoutUuid.id = 'some-other-id'
-      delete inputWithoutUuid.uuid
-
-      expect(getLinkProps(inputWithoutUuid, input.title)).toMatchObject({
-        to: `${inputWithoutUuid.id}/${inputWithoutUuid.title}`,
+        to: `${input.id}/${input.title}`,
       })
     })
 
@@ -202,7 +189,7 @@ describe('normalizeCMSResults', () => {
           input.title,
         ),
       ).toMatchObject({
-        to: `${input.uuid}/${field_special_type}`,
+        to: `${input.id}/${field_special_type}`,
       })
     })
 

--- a/src/normalizations/cms/normalizeCMSResults.test.js
+++ b/src/normalizations/cms/normalizeCMSResults.test.js
@@ -10,7 +10,6 @@ import normalizeCMSResults, {
 jest.mock('../../app/links')
 jest.mock('../../store/redux-first-router/actions')
 
-// const toArticleDetailSpy = jest.fn((id, slug) => `${id}/${slug}`)
 toArticleDetail.mockImplementation((id, slug) => `${id}/${slug}`)
 toSpecialDetail.mockImplementation((id, slug) => `${id}/${slug}`)
 

--- a/src/normalizations/cms/normalizeCMSResults.test.js
+++ b/src/normalizations/cms/normalizeCMSResults.test.js
@@ -10,8 +10,9 @@ import normalizeCMSResults, {
 jest.mock('../../app/links')
 jest.mock('../../store/redux-first-router/actions')
 
-toArticleDetail.mockImplementation(() => 'to-article')
-toSpecialDetail.mockImplementation(() => 'to-special')
+// const toArticleDetailSpy = jest.fn((id, slug) => `${id}/${slug}`)
+toArticleDetail.mockImplementation((id, slug) => `${id}/${slug}`)
+toSpecialDetail.mockImplementation((id, slug) => `${id}/${slug}`)
 
 describe('normalizeCMSResults', () => {
   describe('getLocaleFormattedDate', () => {
@@ -101,12 +102,11 @@ describe('normalizeCMSResults', () => {
     })
 
     it('returns an object with dates from field_publication_year, field_publication_month and field_publication_day 1', () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
+      /* eslint-disable @typescript-eslint/naming-convention */
       const field_publication_year = 2020
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const field_publication_month = 1
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const field_publication_day = 1
+      /* eslint-enable @typescript-eslint/naming-convention */
       const { localeDate, localeDateFormatted } = getLocaleFormattedDate({
         field_publication_year,
         field_publication_month,
@@ -164,6 +164,10 @@ describe('normalizeCMSResults', () => {
   }
 
   describe('getLinkProps', () => {
+    // beforeEach(() => {
+    //   toArticleDetailSpy.mockReset()
+    // })
+
     it('sets the "to" prop', () => {
       expect(
         getLinkProps(
@@ -174,7 +178,20 @@ describe('normalizeCMSResults', () => {
           input.title,
         ),
       ).toMatchObject({
-        to: 'to-article',
+        to: `${input.uuid}/${input.title}`,
+      })
+    })
+
+    it('falls back to the id prop when the uuid prop is missing', () => {
+      const inputWithoutUuid = {
+        ...input,
+        type: CmsType.Article,
+      }
+      inputWithoutUuid.id = 'some-other-id'
+      delete inputWithoutUuid.uuid
+
+      expect(getLinkProps(inputWithoutUuid, input.title)).toMatchObject({
+        to: `${inputWithoutUuid.id}/${inputWithoutUuid.title}`,
       })
     })
 
@@ -191,7 +208,7 @@ describe('normalizeCMSResults', () => {
           input.title,
         ),
       ).toMatchObject({
-        to: 'to-special',
+        to: `${input.uuid}/${field_special_type}`,
       })
     })
 

--- a/src/shared/services/cms/cms-json-api-normalizer.js
+++ b/src/shared/services/cms/cms-json-api-normalizer.js
@@ -3,23 +3,21 @@ import normalize from 'json-api-normalize'
 
 export const getType = (type) => type && type.replace('node--', '')
 
-function getNormalizedItem(item, extraData = {}) {
+const getNormalizedItem = (item, extraData = {}) =>
   // Make sure the correct fields have data here to be used by normalizeCMSResults()
-  return {
+  ({
     ...extraData,
     ...item,
     type: getType(item.type),
     intro: item.field_intro,
     short_title: item.field_short_title,
-    uuid: item.id,
     media_image_url: item.field_cover_image
       ? item.field_cover_image.field_media_image.uri.url
       : item.media_image_url,
     teaser_url: item.field_teaser_image
       ? item.field_teaser_image.field_media_image.uri.url
       : item.teaser_url,
-  }
-}
+  })
 
 export const reformatJSONApiResults = (normalizedData) => {
   // In case of a Drupal collection resource the returned data will include several objects that need to be normalized


### PR DESCRIPTION
As it turns out, not every node's data, coming the CMS' REST API, has a value for its prop `uuid`. The code was depending on that and thus threw an error for specific nodes. The cause is that related articles don't get the `uuid` prop from the normalization functions. The solution was to remove the `uuid` prop altogether and have all references point the `id` prop instead.