### PR TITLE
[DI2-328] Fix ResizeObserver support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6428,6 +6428,15 @@
         "redux": "^4.0.0"
       }
     },
+    "@types/react-resize-detector": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-resize-detector/-/react-resize-detector-5.0.0.tgz",
+      "integrity": "sha512-JTqR0G+RcC6Guqi/JXQBq3jewflumUGd4fDUucmZN9L1d8TZuRHzDTtrmgYWrgLvRTBTV6FjegmLeV1UnrIuzw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-router": {
       "version": "5.1.10",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.10.tgz",
@@ -7954,6 +7963,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "blob-util": {
       "version": "2.0.2",
@@ -11775,6 +11794,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
       "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -16039,6 +16065,13 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -23731,7 +23764,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@types/react-dom": "^17.0.1",
     "@types/react-helmet": "^6.1.0",
     "@types/react-redux": "^7.1.16",
+    "@types/react-resize-detector": "^5.0.0",
     "@types/react-router-dom": "^5.1.7",
     "@types/redux-first-router-link": "^1.4.4",
     "@types/redux-first-router-restore-scroll": "^1.2.1",

--- a/src/map/components/leaflet/MapLeaflet.jsx
+++ b/src/map/components/leaflet/MapLeaflet.jsx
@@ -5,7 +5,7 @@ import 'leaflet.markercluster'
 import PropTypes from 'prop-types'
 import { Component } from 'react'
 import { GeoJSON, Map, ScaleControl, TileLayer, ZoomControl } from 'react-leaflet'
-import ReactResizeDetector from 'react-resize-detector'
+import ReactResizeDetector from 'react-resize-detector/build/withPolyfill'
 import {
   dataSelectionType,
   DEFAULT_LAT,


### PR DESCRIPTION
Fixes an issue with the lack of support for `ResizeObserver`. Caused by an upgrade of package `https://www.npmjs.com/package/react-resize-detector` [from version `5.2.0` to `6.6.0`](https://github.com/Amsterdam/atlas/pull/4001). The latest version dropped the polyfill for the observer. See https://github.com/maslianok/react-resize-detector/releases/tag/v6.0.0-alpha.1 for reference.