### PR TITLE
Remove type definitions for react-resize-detector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6428,15 +6428,6 @@
         "redux": "^4.0.0"
       }
     },
-    "@types/react-resize-detector": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react-resize-detector/-/react-resize-detector-5.0.0.tgz",
-      "integrity": "sha512-JTqR0G+RcC6Guqi/JXQBq3jewflumUGd4fDUucmZN9L1d8TZuRHzDTtrmgYWrgLvRTBTV6FjegmLeV1UnrIuzw==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/react-router": {
       "version": "5.1.10",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.10.tgz",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "@types/react-dom": "^17.0.1",
     "@types/react-helmet": "^6.1.0",
     "@types/react-redux": "^7.1.16",
-    "@types/react-resize-detector": "^5.0.0",
     "@types/react-router-dom": "^5.1.7",
     "@types/redux-first-router-link": "^1.4.4",
     "@types/redux-first-router-restore-scroll": "^1.2.1",

--- a/src/map/components/leaflet/MapLeaflet.jsx
+++ b/src/map/components/leaflet/MapLeaflet.jsx
@@ -5,6 +5,7 @@ import 'leaflet.markercluster'
 import PropTypes from 'prop-types'
 import { Component } from 'react'
 import { GeoJSON, Map, ScaleControl, TileLayer, ZoomControl } from 'react-leaflet'
+// TODO: Polyfill is needed for Firefox 68 ESR, can be removed once we drop support.
 import ReactResizeDetector from 'react-resize-detector/build/withPolyfill'
 import {
   dataSelectionType,


### PR DESCRIPTION
These are already included by the library itself as it's written in TypeScript since version 6.